### PR TITLE
Create a CLI utility that takes a repository and generates an html page of all commits

### DIFF
--- a/scripts/generate_commits_html.py
+++ b/scripts/generate_commits_html.py
@@ -1,0 +1,117 @@
+import os
+import sys
+import requests
+import jinja2
+import argparse
+
+def get_commits(repository, token):
+    url = "https://api.github.com/graphql"
+    headers = {"Authorization": f"Bearer {token}"}
+    query = """
+    query($owner: String!, $name: String!, $cursor: String) {
+        repository(owner: $owner, name: $name) {
+            ref(qualifiedName: "main") {
+                target {
+                    ... on Commit {
+                        history(first: 100, after: $cursor) {
+                            edges {
+                                node {
+                                    oid
+                                    message
+                                    committedDate
+                                    associatedPullRequests(first: 1) {
+                                        edges {
+                                            node {
+                                                number
+                                                title
+                                                body
+                                                url
+                                                merged
+                                                mergedAt
+                                                closingIssuesReferences(first: 10) {
+                                                    edges {
+                                                        node {
+                                                            number
+                                                            title
+                                                            url
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            pageInfo {
+                                endCursor
+                                hasNextPage
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    owner, name = repository.split('/')
+    commits = []
+    cursor = None
+
+    while True:
+        variables = {"owner": owner, "name": name, "cursor": cursor}
+        response = requests.post(url, json={"query": query, "variables": variables}, headers=headers)
+        if response.status_code != 200:
+            raise Exception(f"Query failed to run by returning code of {response.status_code}. {query}")
+
+        result = response.json()
+        history = result["data"]["repository"]["ref"]["target"]["history"]
+        for edge in history["edges"]:
+            commit = edge["node"]
+            commits.append(commit)
+
+        if not history["pageInfo"]["hasNextPage"]:
+            break
+        cursor = history["pageInfo"]["endCursor"]
+
+    return commits
+
+def get_pull_request(commit):
+    if commit["associatedPullRequests"]["edges"]:
+        return commit["associatedPullRequests"]["edges"][0]["node"]
+    return None
+
+def get_issues(pull_request):
+    issues = []
+    if pull_request and pull_request["closingIssuesReferences"]["edges"]:
+        for edge in pull_request["closingIssuesReferences"]["edges"]:
+            issues.append(edge["node"])
+    return issues
+
+def generate_html(commits, template_path, output_path):
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(searchpath="./"))
+    template = env.get_template(template_path)
+    html_content = template.render(commits=commits)
+    with open(output_path, "w") as f:
+        f.write(html_content)
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML page of all commits from a repository")
+    parser.add_argument("--repository", required=True, help="Repository in the format 'owner/name'")
+    parser.add_argument("--output", required=True, help="Output HTML file path")
+    args = parser.parse_args()
+
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+
+    commits = get_commits(args.repository, token)
+    for commit in commits:
+        commit["pull_request"] = get_pull_request(commit)
+        if commit["pull_request"]:
+            commit["issues"] = get_issues(commit["pull_request"])
+
+    generate_html(commits, "scripts/template.html", args.output)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Commit History</title>
+  </head>
+  <body>
+    <h1>Commit History</h1>
+    <ul>
+      {% for commit in commits %}
+      <li>
+        <p><strong>Commit:</strong> {{ commit.oid }}</p>
+        <p><strong>Message:</strong> {{ commit.message }}</p>
+        <p><strong>Date:</strong> {{ commit.committedDate }}</p>
+        {% if commit.pull_request %}
+        <p><strong>Pull Request:</strong> <a href="{{ commit.pull_request.url }}">{{ commit.pull_request.title }}</a></p>
+        <p><strong>PR Merged:</strong> {{ commit.pull_request.merged }}</p>
+        <p><strong>PR Merged At:</strong> {{ commit.pull_request.mergedAt }}</p>
+        {% if commit.issues %}
+        <p><strong>Issues:</strong></p>
+        <ul>
+          {% for issue in commit.issues %}
+          <li><a href="{{ issue.url }}">{{ issue.title }}</a></li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
Related to #1

Add a CLI utility to generate an HTML page of all commits from a specified repository using the Github GraphQL API and Jinja template.

* **scripts/generate_commits_html.py**
  - Add a Python script named `generate_commits_html.py`.
  - Import necessary libraries: `os`, `sys`, `requests`, `jinja2`, `argparse`.
  - Define a function `get_commits` to pull commit history using Github GraphQL API.
  - Define a function `get_pull_request` to get pull request details for a commit.
  - Define a function `get_issues` to get issues referenced in a pull request.
  - Define a function `generate_html` to generate HTML using Jinja template.
  - Define the main function to parse CLI arguments and call the above functions.

* **scripts/template.html**
  - Add a Jinja template named `template.html`.
  - Create a basic HTML structure resembling `index.html`.
  - Add placeholders for commit data, pull request data, and issue data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/4?shareId=50c4c54c-29be-4753-a144-8e36c3023afa).