### PR TITLE
Create a CLI utility that generates a summary of significant activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # nlstory2
+
+## CLI Utility for Generating Repository Summary
+
+This repository includes a CLI utility that generates an HTML summary of significant activity from a repository using the Github GraphQL API.
+
+### Usage
+
+To use the CLI utility, run the following command:
+
+```
+python scripts/generate_summary.py --repository <owner/repo> --output <output_file>
+```
+
+### Parameters
+
+- `--repository`: The repository to fetch data from (format: owner/repo).
+- `--output`: The output HTML file.
+
+### Example
+
+```
+python scripts/generate_summary.py --repository abrie/nlstory2 --output summary.html
+```
+
+### Authentication
+
+The utility requires the GITHUB_TOKEN environment variable for authentication. Make sure to set this variable before running the utility.
+
+```
+export GITHUB_TOKEN=<your_github_token>
+```

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -1,0 +1,75 @@
+import argparse
+import os
+import requests
+import jinja2
+
+def get_commits(repository):
+    url = "https://api.github.com/graphql"
+    headers = {
+        "Authorization": f"Bearer {os.getenv('GITHUB_TOKEN')}"
+    }
+    query = """
+    {
+      repository(owner: "%s", name: "%s") {
+        defaultBranchRef {
+          target {
+            ... on Commit {
+              history(first: 100) {
+                edges {
+                  node {
+                    message
+                    oid
+                    committedDate
+                    associatedPullRequests(first: 1) {
+                      edges {
+                        node {
+                          title
+                          number
+                          merged
+                          mergeCommit {
+                            oid
+                          }
+                          associatedIssues(first: 1) {
+                            edges {
+                              node {
+                                title
+                                number
+                                state
+                                url
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """ % tuple(repository.split('/'))
+    response = requests.post(url, json={'query': query}, headers=headers)
+    return response.json()
+
+def generate_html(commits, output_file):
+    template_loader = jinja2.FileSystemLoader(searchpath="scripts/templates")
+    template_env = jinja2.Environment(loader=template_loader)
+    template = template_env.get_template("summary_template.html")
+    output = template.render(commits=commits)
+    with open(output_file, "w") as f:
+        f.write(output)
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a summary of significant activity from a repository.")
+    parser.add_argument("--repository", required=True, help="The repository to fetch data from (format: owner/repo).")
+    parser.add_argument("--output", required=True, help="The output HTML file.")
+    args = parser.parse_args()
+
+    commits = get_commits(args.repository)
+    generate_html(commits, args.output)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/templates/summary_template.html
+++ b/scripts/templates/summary_template.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Repository Summary</title>
+  </head>
+  <body>
+    <h1>Repository Summary</h1>
+    <ul>
+      {% for commit in commits %}
+        <li>
+          <p>{{ commit.node.message }}</p>
+          {% if commit.node.associatedPullRequests.edges %}
+            <p>Merge: Yes</p>
+            <p>Pull Request: {{ commit.node.associatedPullRequests.edges[0].node.title }}</p>
+            {% if commit.node.associatedPullRequests.edges[0].node.associatedIssues.edges %}
+              <p>Issue: {{ commit.node.associatedPullRequests.edges[0].node.associatedIssues.edges[0].node.title }}</p>
+            {% endif %}
+          {% else %}
+            <p>Merge: No</p>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+    <h2>Unmerged Pull Requests</h2>
+    <ul>
+      {% for commit in commits %}
+        {% if commit.node.associatedPullRequests.edges %}
+          {% for pr in commit.node.associatedPullRequests.edges %}
+            {% if not pr.node.merged %}
+              <li>
+                <p>Pull Request: {{ pr.node.title }}</p>
+                <p>Issue: {{ pr.node.associatedIssues.edges[0].node.title }}</p>
+              </li>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
Related to #1

Add a CLI utility to generate an HTML summary of significant activity from a repository using the Github GraphQL API.

* Add `scripts/generate_summary.py` to fetch commits, generate HTML, and handle CLI arguments.
* Add `scripts/templates/summary_template.html` as a jinja template for the HTML summary.
* Modify `README.md` to include usage instructions, parameters, example, and authentication details.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/8?shareId=c732b60c-531b-49d9-b371-53003b932a1a).