### PR TITLE
Create a CLI utility that takes a repository and generates a summary of significant activity

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -14,11 +14,18 @@ def fetch_issues_and_prs(repository, token):
             title
             url
             createdAt
-            pullRequests(first: 10) {
+            timelineItems(itemTypes: CROSS_REFERENCED_EVENT, first: 10) {
               nodes {
-                title
-                url
-                createdAt
+                ... on CrossReferencedEvent {
+                  source {
+                    __typename
+                    ... on PullRequest {
+                      title
+                      url
+                      createdAt
+                    }
+                  }
+                }
               }
             }
           }

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -1,0 +1,56 @@
+import argparse
+import os
+import requests
+import jinja2
+
+def fetch_issues_and_prs(repository, token):
+    url = "https://api.github.com/graphql"
+    headers = {"Authorization": f"Bearer {token}"}
+    query = """
+    {
+      repository(owner: "%s", name: "%s") {
+        issues(first: 100, orderBy: {field: CREATED_AT, direction: ASC}) {
+          nodes {
+            title
+            url
+            createdAt
+            pullRequests(first: 10) {
+              nodes {
+                title
+                url
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+    """ % tuple(repository.split('/'))
+    response = requests.post(url, json={'query': query}, headers=headers)
+    if response.status_code == 200:
+        return response.json()['data']['repository']['issues']['nodes']
+    else:
+        raise Exception(f"Query failed to run by returning code of {response.status_code}. {query}")
+
+def generate_html(issues, template_path, output_path):
+    with open(template_path) as file_:
+        template = jinja2.Template(file_.read())
+    html_content = template.render(issues=issues)
+    with open(output_path, 'w') as file_:
+        file_.write(html_content)
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a summary of significant activity in a Github repository.")
+    parser.add_argument('--repository', required=True, help='The repository to fetch data from (format: owner/repo).')
+    parser.add_argument('--output', required=True, help='The output HTML file.')
+    args = parser.parse_args()
+
+    token = os.getenv('GITHUB_TOKEN')
+    if not token:
+        raise EnvironmentError("GITHUB_TOKEN environment variable not set.")
+
+    issues = fetch_issues_and_prs(args.repository, token)
+    generate_html(issues, 'scripts/template.html', args.output)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Repository Summary</title>
+  </head>
+  <body>
+    <h1>Repository Summary</h1>
+    <h2>Issues</h2>
+    <ul>
+      {% for issue in issues %}
+        <li>
+          <a href="{{ issue.url }}">{{ issue.title }}</a> - {{ issue.createdAt }}
+          <ul>
+            {% for pr in issue.pullRequests.nodes %}
+              <li>
+                <a href="{{ pr.url }}">{{ pr.title }}</a> - {{ pr.createdAt }}
+              </li>
+            {% endfor %}
+          </ul>
+        </li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
Related to #1

Add a CLI utility to generate a summary of significant activity in a Github repository.

* Create `scripts/generate_summary.py` to fetch issues and pull requests using the Github GraphQL API, generate an HTML summary using a Jinja template, and handle CLI arguments.
* Add `scripts/template.html` as a Jinja template for generating the HTML summary.
* Use the `GITHUB_TOKEN` environment variable for authentication.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/9?shareId=97c191eb-5a77-436a-9349-785b35bf6430).