### PR TITLE
Add activity summary CLI utility

### DIFF
--- a/scripts/activity_summary.py
+++ b/scripts/activity_summary.py
@@ -1,0 +1,75 @@
+import os
+import requests
+import argparse
+from jinja2 import Environment, FileSystemLoader
+
+GITHUB_API_URL = "https://api.github.com/graphql"
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+
+def get_issues_and_pull_requests(repository):
+    query = """
+    {
+      repository(owner: "%s", name: "%s") {
+        issues(first: 100, states: [OPEN, CLOSED]) {
+          nodes {
+            title
+            createdAt
+            timelineItems(itemTypes: CROSS_REFERENCED_EVENT) {
+              nodes {
+                ... on CrossReferencedEvent {
+                  source {
+                    ... on PullRequest {
+                      title
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """ % tuple(repository.split('/'))
+
+    headers = {"Authorization": f"Bearer {GITHUB_TOKEN}"}
+    response = requests.post(GITHUB_API_URL, json={'query': query}, headers=headers)
+    if response.status_code == 200:
+        return response.json()['data']['repository']['issues']['nodes']
+    else:
+        raise Exception(f"Query failed to run by returning code of {response.status_code}. {query}")
+
+def generate_summary(issues):
+    summary = []
+    for issue in issues:
+        summary.append({
+            'title': issue['title'],
+            'createdAt': issue['createdAt'],
+            'pullRequests': [
+                {
+                    'title': pr['source']['title'],
+                    'createdAt': pr['source']['createdAt']
+                } for pr in issue['timelineItems']['nodes']
+            ]
+        })
+    summary.sort(key=lambda x: x['createdAt'])
+    return summary
+
+def render_html(summary, output_file):
+    env = Environment(loader=FileSystemLoader('scripts/templates'))
+    template = env.get_template('summary_template.html')
+    with open(output_file, 'w') as f:
+        f.write(template.render(summary=summary))
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate a summary of significant activity from a GitHub repository.')
+    parser.add_argument('--repository', required=True, help='GitHub repository in the format owner/repo')
+    parser.add_argument('--output', required=True, help='Output HTML file')
+    args = parser.parse_args()
+
+    issues = get_issues_and_pull_requests(args.repository)
+    summary = generate_summary(issues)
+    render_html(summary, args.output)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/templates/summary_template.html
+++ b/scripts/templates/summary_template.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Activity Summary</title>
+  </head>
+  <body>
+    <h1>Activity Summary</h1>
+    <ul>
+      {% for item in summary %}
+        <li>
+          <strong>{{ item.title }}</strong> ({{ item.createdAt }})
+          <ul>
+            {% for pr in item.pullRequests %}
+              <li>{{ pr.title }} ({{ pr.createdAt }})</li>
+            {% endfor %}
+          </ul>
+        </li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
Related to #1

Add a CLI utility to generate a summary of significant activity from a GitHub repository and output it as an HTML file.

* Add `scripts/activity_summary.py` to implement the CLI utility.
  - Take `--repository` and `--output` parameters.
  - Use the Github GraphQL API and authenticate using the GITHUB_TOKEN environment variable.
  - Build the summary using all non pull-request issues and their cross-referenced pull requests.
  - Order the summary data chronologically and generate an HTML file using a jinja template.
* Add `scripts/templates/summary_template.html` to serve as the jinja template for the HTML output.
  - Derive the template from the existing `index.html` file.
  - Include placeholders for the summary data to be populated by the CLI utility.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/10?shareId=e56dfcd4-0012-4854-afff-f411425f3a8d).