### PR TITLE
Create a CLI utility to generate repository activity summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # nlstory2
+
+## CLI Utility for Generating Summary of Significant Activity
+
+This repository includes a CLI utility that generates a summary of significant activity from a Github repository using the Github GraphQL API and outputs it as an HTML file.
+
+### Usage
+
+To use the CLI utility, run the following command:
+
+```sh
+python scripts/generate_summary.py --repository <owner/repo> --output <output_file>
+```
+
+### Parameters
+
+- `--repository`: The repository to fetch data from (e.g., owner/repo).
+- `--output`: The output HTML file.
+
+### Example
+
+```sh
+python scripts/generate_summary.py --repository abrie/nlstory2 --output summary.html
+```
+
+Make sure to set the `GITHUB_TOKEN` environment variable with your Github token before running the utility.
+
+```sh
+export GITHUB_TOKEN=your_github_token
+```

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -1,0 +1,95 @@
+import argparse
+import os
+import requests
+import jinja2
+
+def get_github_data(repository):
+    url = "https://api.github.com/graphql"
+    headers = {
+        "Authorization": f"Bearer {os.getenv('GITHUB_TOKEN')}"
+    }
+    query = """
+    query($owner: String!, $name: String!, $cursor: String) {
+      repository(owner: $owner, name: $name) {
+        issues(first: 100, after: $cursor) {
+          edges {
+            node {
+              title
+              createdAt
+              timelineItems(itemTypes: CROSS_REFERENCED_EVENT, first: 100) {
+                edges {
+                  node {
+                    ... on CrossReferencedEvent {
+                      source {
+                        ... on PullRequest {
+                          title
+                          createdAt
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    }
+    """
+    owner, name = repository.split('/')
+    data = []
+    cursor = None
+    while True:
+        variables = {"owner": owner, "name": name, "cursor": cursor}
+        response = requests.post(url, json={'query': query, 'variables': variables}, headers=headers)
+        result = response.json()
+        issues = result['data']['repository']['issues']['edges']
+        for issue in issues:
+            data.append(issue['node'])
+        if not result['data']['repository']['issues']['pageInfo']['hasNextPage']:
+            break
+        cursor = result['data']['repository']['issues']['pageInfo']['endCursor']
+    return data
+
+def generate_summary(data):
+    summary = []
+    for issue in data:
+        if 'pullRequest' not in issue:
+            summary.append({
+                'title': issue['title'],
+                'createdAt': issue['createdAt'],
+                'pullRequests': [
+                    {
+                        'title': pr['node']['source']['title'],
+                        'createdAt': pr['node']['source']['createdAt']
+                    }
+                    for pr in issue['timelineItems']['edges']
+                ]
+            })
+    summary.sort(key=lambda x: x['createdAt'])
+    return summary
+
+def create_html(summary, output_file):
+    template_loader = jinja2.FileSystemLoader(searchpath="./scripts/templates")
+    template_env = jinja2.Environment(loader=template_loader)
+    template = template_env.get_template("summary_template.html")
+    output = template.render(summary=summary)
+    with open(output_file, "w") as f:
+        f.write(output)
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a summary of significant activity from a Github repository.")
+    parser.add_argument("--repository", required=True, help="The repository to fetch data from (e.g., owner/repo).")
+    parser.add_argument("--output", required=True, help="The output HTML file.")
+    args = parser.parse_args()
+
+    data = get_github_data(args.repository)
+    summary = generate_summary(data)
+    create_html(summary, args.output)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/templates/summary_template.html
+++ b/scripts/templates/summary_template.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Summary of Significant Activity</title>
+  </head>
+  <body>
+    <h1>Summary of Significant Activity</h1>
+    <ul>
+      {% for item in summary %}
+        <li>
+          <strong>{{ item.title }}</strong> ({{ item.createdAt }})
+          <ul>
+            {% for pr in item.pullRequests %}
+              <li>{{ pr.title }} ({{ pr.createdAt }})</li>
+            {% endfor %}
+          </ul>
+        </li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
Related to #1

Add a CLI utility to generate a summary of significant activity from a Github repository using the Github GraphQL API and output it as an HTML file.

* **New Python Script**: Add `scripts/generate_summary.py` to fetch data from Github, process it, and generate an HTML summary.
* **Jinja Template**: Add `scripts/templates/summary_template.html` to define the HTML structure for the summary.
* **README Update**: Update `README.md` with usage instructions and examples for the new CLI utility.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/11?shareId=ae6a8f74-41b0-41a8-bd04-f644530b6bb2).