### PR TITLE
Create a CLI utility to generate a summary of significant activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # nlstory2
+
+## CLI Utility for Generating Summary of Significant Activity
+
+This repository contains a CLI utility that generates a summary of significant activity from a repository and outputs it as an HTML file.
+
+### Usage
+
+To use the CLI utility, run the following command:
+
+```sh
+python scripts/generate_summary.py --repository <owner/repo> --output <output_file>
+```
+
+### Example
+
+```sh
+python scripts/generate_summary.py --repository abrie/nlstory2 --output summary.html
+```
+
+### Requirements
+
+- Python 3.x
+- `requests` library
+- `jinja2` library
+- GITHUB_TOKEN environment variable for authentication
+
+### Installation
+
+To install the required libraries, run:
+
+```sh
+pip install requests jinja2
+```
+
+### Setting the GITHUB_TOKEN
+
+Make sure to set the GITHUB_TOKEN environment variable before running the utility. You can do this by running:
+
+```sh
+export GITHUB_TOKEN=<your_github_token>
+```

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -1,0 +1,104 @@
+import requests
+import os
+import argparse
+import jinja2
+
+def fetch_issues(owner, repo):
+    url = 'https://api.github.com/graphql'
+    headers = {
+        'Authorization': f'bearer {os.getenv("GITHUB_TOKEN")}'
+    }
+    query = """
+    query($owner: String!, $repo: String!, $cursor: String) {
+        repository(owner: $owner, name: $repo) {
+            issues(first: 100, after: $cursor) {
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                edges {
+                    node {
+                        __typename
+                        title
+                        createdAt
+                        timelineItems(first: 100) {
+                            nodes {
+                                ... on CrossReferencedEvent {
+                                    source {
+                                        ... on PullRequest {
+                                            __typename
+                                            merged
+                                            number
+                                            title
+                                            createdAt
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    issues = []
+    cursor = None
+    while True:
+        variables = {
+            'owner': owner,
+            'repo': repo,
+            'cursor': cursor
+        }
+        response = requests.post(url, json={'query': query, 'variables': variables}, headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+            issues.extend(data['data']['repository']['issues']['edges'])
+            if data['data']['repository']['issues']['pageInfo']['hasNextPage']:
+                cursor = data['data']['repository']['issues']['pageInfo']['endCursor']
+            else:
+                break
+        else:
+            raise Exception(f"Query failed to run by returning code of {response.status_code}. {query}")
+    return issues
+
+def generate_summary(issues):
+    summary = []
+    for issue in issues:
+        issue_node = issue['node']
+        summary.append({
+            'type': issue_node['__typename'],
+            'title': issue_node['title'],
+            'createdAt': issue_node['createdAt']
+        })
+        for event in issue_node['timelineItems']['nodes']:
+            if 'source' in event and event['source']['__typename'] == 'PullRequest' and event['source']['merged']:
+                summary.append({
+                    'type': event['source']['__typename'],
+                    'title': event['source']['title'],
+                    'createdAt': event['source']['createdAt']
+                })
+    summary.sort(key=lambda x: x['createdAt'])
+    return summary
+
+def render_html(summary, output_file):
+    template_loader = jinja2.FileSystemLoader(searchpath="./scripts")
+    template_env = jinja2.Environment(loader=template_loader)
+    template = template_env.get_template("template.html")
+    output = template.render(summary=summary)
+    with open(output_file, 'w') as f:
+        f.write(output)
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate a summary of significant activity from a repository.')
+    parser.add_argument('--repository', required=True, help='The repository to fetch data from (format: owner/repo).')
+    parser.add_argument('--output', required=True, help='The output HTML file.')
+    args = parser.parse_args()
+
+    owner, repo = args.repository.split('/')
+    issues = fetch_issues(owner, repo)
+    summary = generate_summary(issues)
+    render_html(summary, args.output)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Summary of Significant Activity</title>
+  </head>
+  <body>
+    <h1>Summary of Significant Activity</h1>
+    <ul>
+      {% for item in summary %}
+        <li>{{ item.createdAt }} - {{ item.type }}: {{ item.title }}</li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
Related to #1

Add a CLI utility to generate a summary of significant activity from a repository and output it as an HTML file.

* Create `scripts/generate_summary.py` to fetch issues and cross-referenced pull requests from the Github GraphQL API, generate a summary, and render it as an HTML file using a jinja template.
* Add `scripts/template.html` as a jinja template for rendering the summary data.
* Update `README.md` to document the usage of the CLI utility, including example commands, requirements, and instructions for setting the GITHUB_TOKEN environment variable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/issues/1?shareId=XXXX-XXXX-XXXX-XXXX).