### PR TITLE
Add summary generator CLI utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # nlstory2
+
+## Summary Generator CLI Utility
+
+This repository includes a CLI utility that generates a summary of significant activity from a GitHub repository using the GitHub GraphQL API and outputs it as an HTML file.
+
+### Usage
+
+To use the summary generator, run the following command:
+
+```sh
+python scripts/summary_generator.py --repository <owner/repo> --output <output_file>
+```
+
+### Parameters
+
+- `--repository`: The repository to generate the summary from (e.g., `owner/repo`).
+- `--output`: The output HTML file.
+
+### Example
+
+```sh
+python scripts/summary_generator.py --repository abrie/nlstory2 --output summary.html
+```
+
+This will generate a summary of significant activity from the `abrie/nlstory2` repository and save it to `summary.html`.
+
+### Requirements
+
+- Python 3.x
+- `requests` library
+- `jinja2` library
+
+### Installation
+
+To install the required libraries, run:
+
+```sh
+pip install requests jinja2
+```
+
+### Environment Variables
+
+The script uses the `GITHUB_TOKEN` environment variable for authentication with the GitHub GraphQL API. Make sure to set this environment variable before running the script.
+
+```sh
+export GITHUB_TOKEN=<your_github_token>
+```

--- a/scripts/summary_generator.py
+++ b/scripts/summary_generator.py
@@ -1,0 +1,88 @@
+import os
+import requests
+import argparse
+from jinja2 import Environment, FileSystemLoader
+
+GITHUB_API_URL = "https://api.github.com/graphql"
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+
+def get_issues_and_pull_requests(repository):
+    query = """
+    query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+            issues(first: 100) {
+                edges {
+                    node {
+                        title
+                        createdAt
+                        url
+                        timelineItems(itemTypes: CROSS_REFERENCED_EVENT, first: 100) {
+                            edges {
+                                node {
+                                    ... on CrossReferencedEvent {
+                                        source {
+                                            ... on PullRequest {
+                                                title
+                                                createdAt
+                                                url
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    owner, name = repository.split('/')
+    issues = []
+
+    response = requests.post(
+        GITHUB_API_URL,
+        json={'query': query, 'variables': {'owner': owner, 'name': name}},
+        headers={'Authorization': f'bearer {GITHUB_TOKEN}'}
+    )
+    data = response.json()
+    issues.extend(data['data']['repository']['issues']['edges'])
+
+    return issues
+
+def generate_summary(issues):
+    summary = []
+    for issue in issues:
+        summary.append({
+            'title': issue['node']['title'],
+            'createdAt': issue['node']['createdAt'],
+            'url': issue['node']['url']
+        })
+        for event in issue['node']['timelineItems']['edges']:
+            if 'source' in event['node'] and 'title' in event['node']['source']:
+                summary.append({
+                    'title': event['node']['source']['title'],
+                    'createdAt': event['node']['source']['createdAt'],
+                    'url': event['node']['source']['url']
+                })
+    summary.sort(key=lambda x: x['createdAt'])
+    return summary
+
+def render_html(summary, output_file):
+    env = Environment(loader=FileSystemLoader('scripts'))
+    template = env.get_template('template.html')
+    with open(output_file, 'w') as f:
+        f.write(template.render(summary=summary))
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate a summary of significant activity from a repository.')
+    parser.add_argument('--repository', required=True, help='The repository to generate the summary from (e.g., owner/repo).')
+    parser.add_argument('--output', required=True, help='The output HTML file.')
+    args = parser.parse_args()
+
+    issues = get_issues_and_pull_requests(args.repository)
+    summary = generate_summary(issues)
+    render_html(summary, args.output)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Summary of Significant Activity</title>
+  </head>
+  <body>
+    <h1>Summary of Significant Activity</h1>
+    <ul>
+      {% for item in summary %}
+        <li>
+          <a href="{{ item.url }}">{{ item.title }}</a> - {{ item.createdAt }}
+        </li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
Related to #1

Add a CLI utility to generate a summary of significant activity from a GitHub repository.

* Add `scripts/summary_generator.py` to generate a summary using the GitHub GraphQL API.
  * Take CLI parameters `--repository` and `--output`.
  * Authenticate using the GITHUB_TOKEN environment variable.
  * Build the summary using non pull-request issues and cross-referenced pull requests.
  * Order the summary data chronologically and print one-line descriptions.
  * Generate an HTML file from a jinja template.

* Add `scripts/template.html` as a jinja template for the summary output.
  * Add placeholders for the summary data.

* Update `README.md` to include documentation for the new CLI utility.
  * Add usage instructions and examples.
  * Add requirements and installation steps.
  * Add information about the GITHUB_TOKEN environment variable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/13?shareId=cf115842-5bd9-46e1-b141-37b014696f1d).