### PR TITLE
Create a Python utility to do a Github GraphQL query and output the result as JSON

### DIFF
--- a/scripts/github_query.py
+++ b/scripts/github_query.py
@@ -1,0 +1,52 @@
+import requests
+import json
+import os
+import argparse
+
+def get_issues(repository):
+    url = 'https://api.github.com/graphql'
+    token = os.getenv('GITHUB_TOKEN')
+    headers = {'Authorization': f'bearer {token}'}
+    query = """
+    {
+        repository(owner: "%s", name: "%s") {
+            issues(first: 100) {
+                edges {
+                    node {
+                        __typename
+                        title
+                        timelineItems(first: 100) {
+                            nodes {
+                                ... on CrossReferencedEvent {
+                                    source {
+                                        ... on PullRequest {
+                                            __typename
+                                            merged
+                                            number
+                                            title
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """ % tuple(repository.split('/'))
+    response = requests.post(url, json={'query': query}, headers=headers)
+    return response.json()
+
+def write_output(data, output_file):
+    with open(output_file, 'w') as f:
+        json.dump(data, f, indent=4)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Github GraphQL query utility')
+    parser.add_argument('--repository', required=True, help='Repository in the format owner/name')
+    parser.add_argument('--output', required=True, help='Output file')
+    args = parser.parse_args()
+
+    issues = get_issues(args.repository)
+    write_output(issues, args.output)


### PR DESCRIPTION
Related to #14

Add a Python utility to query Github GraphQL API and output the result as JSON.

* Create a new `scripts/` subfolder.
* Add `scripts/github_query.py` file.
* Import necessary libraries: `requests`, `json`, `os`, `argparse`.
* Define `get_issues` function to query the Github GraphQL API.
* Define `write_output` function to write the result to a JSON file.
* Parse CLI parameters `--repository` and `--output` using `argparse`.
* Call `get_issues` and `write_output` functions in the main block.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/15?shareId=5e6b3cef-95bf-4c4b-8380-4af4ca98294e).