### PR TITLE
Add script to query GitHub GraphQL API

### DIFF
--- a/scripts/query_github.py
+++ b/scripts/query_github.py
@@ -1,0 +1,55 @@
+import os
+import requests
+import json
+
+def query_github():
+    github_token = os.getenv('GITHUB_TOKEN')
+    if not github_token:
+        raise ValueError("GITHUB_TOKEN environment variable not set")
+
+    headers = {
+        "Authorization": f"Bearer {github_token}"
+    }
+
+    query = """
+    {
+        repository(owner: "abrie", name: "nl12") {
+            issues(first: 100) {
+                edges {
+                    node {
+                        __typename
+                        title
+                        timelineItems(first: 100) {
+                            nodes {
+                                ... on CrossReferencedEvent {
+                                    source {
+                                        ... on PullRequest {
+                                            __typename
+                                            merged
+                                            number
+                                            title
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    response = requests.post(
+        'https://api.github.com/graphql',
+        json={'query': query},
+        headers=headers
+    )
+
+    if response.status_code == 200:
+        print(json.dumps(response.json(), indent=2))
+    else:
+        raise Exception(f"Query failed to run by returning code of {response.status_code}. {response.text}")
+
+if __name__ == "__main__":
+    query_github()


### PR DESCRIPTION
Related to #16

Add a Python script to query the GitHub GraphQL API and output the response as JSON.

* Create a new folder `scripts/` in the root directory of the repository.
* Add `scripts/query_github.py` with the following content:
  - Import the `os`, `requests`, and `json` libraries.
  - Define a function `query_github` to perform the GraphQL query.
  - Use the `GITHUB_TOKEN` environment variable for authentication.
  - Send the GraphQL query to the GitHub API and output the response as JSON.
  - Raise an exception if the `GITHUB_TOKEN` environment variable is not set or if the query fails.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/17?shareId=14b7feb8-21a1-401b-a339-e5a80787971f).