### PR TITLE
Add script to query GitHub GraphQL API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # nlstory2
+
+## How to execute the script
+
+1. Ensure you have Node.js installed on your machine.
+2. Clone the repository and navigate to the project directory.
+3. Install the required dependencies by running `npm install`.
+4. Set the `GITHUB_TOKEN` environment variable with your GitHub token.
+5. Run the script using the following command:
+   ```
+   node src/queryGithub.ts
+   ```

--- a/src/queryGithub.ts
+++ b/src/queryGithub.ts
@@ -1,0 +1,42 @@
+import { request, gql } from 'graphql-request';
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+const query = gql`
+  {
+    repository(owner: "abrie", name: "nl12") {
+      issues(first: 100) {
+        edges {
+          node {
+            __typename
+            title
+            timelineItems(first: 100) {
+              nodes {
+                ... on CrossReferencedEvent {
+                  source {
+                    ... on PullRequest {
+                      __typename
+                      merged
+                      number
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const endpoint = 'https://api.github.com/graphql';
+
+const headers = {
+  Authorization: `Bearer ${GITHUB_TOKEN}`,
+};
+
+request(endpoint, query, {}, headers)
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch((error) => console.error(error));


### PR DESCRIPTION
Related to #16

Add a Node script to query the GitHub GraphQL API and output the response as JSON.

* **New Script**: Add `src/queryGithub.ts` to perform the specified GraphQL query using the `GITHUB_TOKEN` environment variable for authentication.
* **Instructions**: Update `README.md` with instructions on how to execute the script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/19?shareId=ddb01da4-322e-4797-ada1-ad88c086730c).