### PR TITLE
Add bash script to query GitHub GraphQL API

### DIFF
--- a/query.json
+++ b/query.json
@@ -1,0 +1,3 @@
+{
+  "query": "{ repository(owner: \"abrie\", name: \"nl12\") { issues(first: 100) { edges { node { __typename title timelineItems(first: 100) { nodes { ... on CrossReferencedEvent { source { ... on PullRequest { __typename merged number title } } } } } } } } } }"
+}

--- a/src/query_github.sh
+++ b/src/query_github.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Check if GITHUB_TOKEN is set
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Error: GITHUB_TOKEN is not set."
+  exit 1
+fi
+
+# Perform the GraphQL query using curl
+response=$(curl -s -H "Authorization: bearer $GITHUB_TOKEN" -X POST -d @query.json https://api.github.com/graphql)
+
+# Output the response as JSON
+echo "$response" | jq .


### PR DESCRIPTION
Related to #16

Add a bash script to query the GitHub GraphQL API and output the response as JSON.

* **query.json**
  - Add the specified GraphQL query to the file.

* **src/query_github.sh**
  - Create a bash script to authenticate with the GitHub GraphQL API using the `GITHUB_TOKEN` environment variable.
  - Use `curl` to perform the GraphQL query stored in `query.json`.
  - Output the response as JSON.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/20?shareId=f9462e17-9894-470c-9163-464801048e9d).