### PR TITLE
Add script to query Github GraphQL API

### DIFF
--- a/src/query.graphql
+++ b/src/query.graphql
@@ -1,0 +1,26 @@
+{
+  repository(owner: "abrie", name: "nl12") {
+    issues(first: 100) {
+      edges {
+        node {
+          __typename
+          title
+          timelineItems(first: 100) {
+            nodes {
+              ... on CrossReferencedEvent {
+                source {
+                  ... on PullRequest {
+                    __typename
+                    merged
+                    number
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/query_github.sh
+++ b/src/query_github.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "GITHUB_TOKEN is not set"
+  exit 1
+fi
+
+QUERY=$(cat query.graphql)
+
+curl -H "Authorization: bearer $GITHUB_TOKEN" -X POST -d "{\"query\": \"$QUERY\"}" https://api.github.com/graphql | jq .


### PR DESCRIPTION
Related to #16

Add a Bash script to query the Github GraphQL API and output the response as JSON.

* Add `src/query_github.sh` to query the Github GraphQL API using the GITHUB_TOKEN environment variable for authentication.
* Add `src/query.graphql` with the provided GraphQL query.
* Read the query from the `query.graphql` file and output the response as JSON using `jq`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/21?shareId=e1d6541d-aa47-476f-9e1f-196a87a93e8b).