### PR TITLE
Query the Github GraphQL API and output the response as JSON

### DIFF
--- a/src/query_github.py
+++ b/src/query_github.py
@@ -1,0 +1,40 @@
+import os
+import requests
+
+def query_github():
+    url = "https://api.github.com/graphql"
+    token = os.getenv("GITHUB_TOKEN")
+    headers = {"Authorization": f"Bearer {token}"}
+    query = """
+    {
+      repository(owner: "abrie", name: "nl12") {
+        issues(first: 100) {
+          edges {
+            node {
+              __typename
+              title
+              timelineItems(first: 100) {
+                nodes {
+                  ... on CrossReferencedEvent {
+                    source {
+                      ... on PullRequest {
+                        __typename
+                        merged
+                        number
+                        title
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    response = requests.post(url, json={'query': query}, headers=headers)
+    print(response.json())
+
+if __name__ == "__main__":
+    query_github()


### PR DESCRIPTION
Related to #16

Add a Python script to query the Github GraphQL API and output the response as JSON.

* Create `src/query_github.py` file
* Import `os` and `requests` libraries
* Define `query_github` function to make the GraphQL query
* Use the `GITHUB_TOKEN` environment variable for authentication
* Print the JSON response from the API

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/22?shareId=c6da80a2-aba3-40a5-aca4-1c61593c283f).