### PR TITLE
Clean up printing of PR request summary under an issue

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -39,9 +39,9 @@ def main():
                                     ... on CrossReferencedEvent {
                                         source {
                                             ... on PullRequest {
-                                                title
                                                 createdAt
                                                 url
+                                                merged
                                             }
                                         }
                                     }
@@ -62,9 +62,9 @@ def main():
         for pr_edge in issue["timelineItems"]["edges"]:
             pr = pr_edge["node"]["source"]
             pull_requests.append({
-                "title": pr["title"],
                 "createdAt": pr["createdAt"],
-                "url": pr["url"]
+                "url": pr["url"],
+                "merged": pr["merged"]
             })
         issues.append({
             "title": issue["title"],

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -10,11 +10,11 @@
     <ul>
       {% for issue in issues %}
       <li>
-        <a href="{{ issue.url }}">{{ issue.title }}</a> - {{ issue.createdAt }}
+        <a href="{{ issue.url }}">{{ issue.createdAt }}</a>
         <ul>
           {% for pr in issue.pull_requests %}
           <li>
-            <a href="{{ pr.url }}">{{ pr.title }}</a> - {{ pr.createdAt }}
+            <a href="{{ pr.url }}">{{ pr.createdAt }}</a> - Merged: {{ pr.merged }}
           </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
Related to #25

Modify the PR request summary to show only the date/time and an indicator of whether it was merged into the main trunk.

* Update `scripts/generate_summary.py` to include the `merged` field for pull requests and remove the `title` field.
* Update `scripts/summary_template.html` to display only the `createdAt` and `merged` fields for pull requests and remove the `title` field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/26?shareId=1d62bb5b-f22e-4d1e-b3e1-0a85e4c0defc).