### PR TITLE
Show a link to each PR request's branch

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -44,6 +44,7 @@ def main():
                                                 createdAt
                                                 url
                                                 merged
+                                                headRefName
                                             }
                                         }
                                     }
@@ -65,7 +66,8 @@ def main():
             pr = pr_edge["node"]["source"]
             pull_requests.append({
                 "createdAt": pr["createdAt"],
-                "merged": pr["merged"]
+                "merged": pr["merged"],
+                "branch": pr["headRefName"]
             })
         issues.append({
             "title": issue["title"],

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -18,6 +18,7 @@
           {% for pr in issue.pull_requests %}
           <li>
             {{ pr.createdAt }} - {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
+            <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}">Branch: {{ pr.branch }}</a>
           </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
Related to #28

Add a link to each pull request's branch in the summary.

* Update `scripts/generate_summary.py` to fetch the branch name for each pull request and include it in the `pull_requests` dictionary.
* Update `scripts/summary_template.html` to include a link to each pull request's branch using the `branch` field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/29?shareId=6a02c1ed-0d6b-489e-9582-cfe60112158d).