### PR TITLE
Remove the list markers

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Repository Summary</title>
     <link rel="stylesheet" href="/public/styles.css">
+    <style>
+      ul, li {
+        list-style-type: none;
+      }
+    </style>
   </head>
   <body>
     <h1>Summary of Significant Activity</h1>


### PR DESCRIPTION
Related to #33

Remove list markers from the `scripts/summary_template.html` file.

* Add inline CSS to set `list-style-type` to "none" for the `<ul>` and `<li>` elements.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/34?shareId=8524885f-67d3-4777-bcb6-7c05d742949f).