### PR TITLE
Render issue body using Markdown

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -1,6 +1,7 @@
 import os
 import requests
 from jinja2 import Environment, FileSystemLoader
+import markdown2
 
 GITHUB_API_URL = "https://api.github.com/graphql"
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
@@ -32,9 +33,15 @@ def query_github(query):
             f"Query failed to run by returning code of {response.status_code}. {query}")
 
 
+def render_markdown(text):
+    return markdown2.markdown(text)
+
+
 def render_template(prompt_events):
     env = Environment(loader=FileSystemLoader('scripts'))
     template = env.get_template('summary_template.html')
+    for event in prompt_events:
+        event.issue["body"] = render_markdown(event.issue["body"])
     return template.render(prompt_events=prompt_events)
 
 

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -18,7 +18,7 @@
       <li class="{% if event.state == 'Unmerged' %}dimmed{% endif %}">
         <details>
           <summary>{{ event.issue.title }}</summary>
-          <p>{{ event.issue.body }}</p>
+          <div class="markdown-body">{{ event.issue.body }}</div>
         </details>
         <ul>
           {% for pr in event.pull_requests %}


### PR DESCRIPTION
Related to #40

Render the body of issues using Markdown.

* Import the `markdown2` library in `scripts/generate_summary.py`.
* Add a `render_markdown` function to convert text to Markdown in `scripts/generate_summary.py`.
* Modify the `render_template` function in `scripts/generate_summary.py` to use the `render_markdown` function for the issue body.
* Change the `<p>` tag to a `<div>` tag with class `markdown-body` for the issue body in `scripts/summary_template.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/41?shareId=cc28ca12-7a56-426f-a5d2-ce381c9adc99).