### PR TITLE
Add ManualEdit type and incorporate it into PromptEvents

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -31,5 +31,17 @@
       </li>
       {% endfor %}
     </ul>
+    <h2>Manual Edits</h2>
+    <ul>
+      {% for edit in manual_edits %}
+      <li>
+        <details>
+          <summary>{{ edit.timestamp }} - {{ edit.message.split('\n')[0] }}</summary>
+          <p>{{ edit.message }}</p>
+          <a href="{{ edit.url }}">View Commit</a>
+        </details>
+      </li>
+      {% endfor %}
+    </ul>
   </body>
 </html>


### PR DESCRIPTION
Related to #42

Add a new type named `ManualEdit` and incorporate it into the list of PromptEvents.

* **scripts/generate_summary.py**
  - Add a new class `ManualEdit` to represent a single commit made to the main trunk.
  - Modify the `main` function to include logic for fetching and processing `ManualEdit` events.
  - Update the `render_template` function to include `ManualEdit` events in the rendered output.
* **scripts/summary_template.html**
  - Add a new section to display `ManualEdit` events using a `details/summary` HTML element.
  - Include the commit's timestamp, brief version of the commit message, full commit message, and a link to the commit.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/44?shareId=2249b3b4-d17e-4b7b-b0cb-4ef9c23fe7d9).