### PR TITLE
Update the Github GraphQL queries to use pagination

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -21,10 +21,10 @@ class PromptEvent:
             return self.issue["createdAt"]
 
 
-def query_github(query):
+def query_github(query, variables=None):
     headers = {"Authorization": f"Bearer {GITHUB_TOKEN}"}
     response = requests.post(GITHUB_API_URL, json={
-                             "query": query}, headers=headers)
+                             "query": query, "variables": variables}, headers=headers)
     if response.status_code == 200:
         return response.json()
     else:
@@ -32,17 +32,15 @@ def query_github(query):
             f"Query failed to run by returning code of {response.status_code}. {query}")
 
 
-def render_template(prompt_events):
-    env = Environment(loader=FileSystemLoader('scripts'))
-    template = env.get_template('summary_template.html')
-    return template.render(prompt_events=prompt_events)
-
-
-def main():
+def fetch_all_issues():
     query = """
-    {
+    query($cursor: String) {
         repository(owner: "abrie", name: "nl12") {
-            issues(first: 100) {
+            issues(first: 100, after: $cursor) {
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
                 edges {
                     node {
                         title
@@ -50,6 +48,10 @@ def main():
                         url
                         body
                         timelineItems(itemTypes: CROSS_REFERENCED_EVENT, first: 100) {
+                            pageInfo {
+                                endCursor
+                                hasNextPage
+                            }
                             edges {
                                 node {
                                     ... on CrossReferencedEvent {
@@ -72,12 +74,49 @@ def main():
         }
     }
     """
-    result = query_github(query)
+    all_issues = []
+    cursor = None
+    while True:
+        result = query_github(query, {"cursor": cursor})
+        issues = result["data"]["repository"]["issues"]["edges"]
+        all_issues.extend(issues)
+        page_info = result["data"]["repository"]["issues"]["pageInfo"]
+        if page_info["hasNextPage"]:
+            cursor = page_info["endCursor"]
+        else:
+            break
+    return all_issues
+
+
+def fetch_all_timeline_items(issue):
+    all_timeline_items = []
+    cursor = None
+    while True:
+        result = query_github(issue["timelineItems"]["query"], {"cursor": cursor})
+        timeline_items = result["data"]["repository"]["issue"]["timelineItems"]["edges"]
+        all_timeline_items.extend(timeline_items)
+        page_info = result["data"]["repository"]["issue"]["timelineItems"]["pageInfo"]
+        if page_info["hasNextPage"]:
+            cursor = page_info["endCursor"]
+        else:
+            break
+    return all_timeline_items
+
+
+def render_template(prompt_events):
+    env = Environment(loader=FileSystemLoader('scripts'))
+    template = env.get_template('summary_template.html')
+    return template.render(prompt_events=prompt_events)
+
+
+def main():
+    issues = fetch_all_issues()
     prompt_events = []
-    for edge in result["data"]["repository"]["issues"]["edges"]:
+    for edge in issues:
         issue = edge["node"]
+        timeline_items = fetch_all_timeline_items(issue)
         pull_requests = []
-        for pr_edge in issue["timelineItems"]["edges"]:
+        for pr_edge in timeline_items:
             pr = pr_edge["node"]["source"]
             pull_requests.append({
                 "createdAt": pr["createdAt"],


### PR DESCRIPTION
Related to #47

Update the Github GraphQL queries in `scripts/generate_summary.py` to use pagination to return all records instead of only 100 records.

* Modify the `query_github` function to accept variables for pagination.
* Add `fetch_all_issues` function to handle pagination for issues.
* Add `fetch_all_timeline_items` function to handle pagination for timeline items.
* Update the `main` function to use the new pagination functions and handle paginated results.
* Modify the GraphQL query to include pagination logic for issues and timeline items.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/48?shareId=e80ec19f-43a3-4415-a807-75a851a54df6).