### PR TITLE
Add a list of main trunk commits not associated with a pull request

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -31,5 +31,13 @@
       </li>
       {% endfor %}
     </ul>
+    <h2>Main Trunk Commits Not Associated with a Pull Request</h2>
+    <ul>
+      {% for commit in main_trunk_commits %}
+      <li>
+        {{ commit.committedDate }} - <a href="{{ commit.url }}">{{ commit.message }}</a>
+      </li>
+      {% endfor %}
+    </ul>
   </body>
 </html>


### PR DESCRIPTION
Related to #50

Add a new section in the output template to list main trunk commits not associated with a pull request.

* Add a new function `get_main_trunk_commits` in `scripts/generate_summary.py` to query the GraphQL API for commits to the main trunk not associated with a pull request.
* Modify the `main` function in `scripts/generate_summary.py` to call `get_main_trunk_commits` and include the results in the output.
* Update the `render_template` function in `scripts/generate_summary.py` to accept and render the main trunk commits.
* Add a new section in `scripts/summary_template.html` to list the main trunk commits, ordered chronologically from earliest to latest.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/51?shareId=cea6e389-711b-4d05-a3a7-74ab3b8e3621).