### PR TITLE
Merge PromptEvents and Main Trunk Commits into one list

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -32,10 +32,10 @@ def query_github(query, variables=None):
             f"Query failed to run by returning code of {response.status_code}. {query}")
 
 
-def render_template(prompt_events, main_trunk_commits):
+def render_template(events):
     env = Environment(loader=FileSystemLoader('scripts'))
     template = env.get_template('summary_template.html')
-    return template.render(prompt_events=prompt_events, main_trunk_commits=main_trunk_commits)
+    return template.render(events=events)
 
 
 def get_main_trunk_commits():
@@ -149,7 +149,10 @@ def main():
     
     main_trunk_commits = get_main_trunk_commits()
     
-    output = render_template(prompt_events, main_trunk_commits)
+    events = prompt_events + main_trunk_commits
+    events.sort(key=lambda x: x.timestamp if isinstance(x, PromptEvent) else x["committedDate"])
+    
+    output = render_template(events)
     with open("index.html", "w") as f:
         f.write(output)
 

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -14,8 +14,9 @@
   <body>
     <h1>Summary of Significant Activity</h1>
     <ul>
-      {% for event in prompt_events %}
-      <li class="{% if event.state == 'Unmerged' %}dimmed{% endif %}">
+      {% for event in events %}
+      <li class="{% if event.state == 'Unmerged' or (event.pull_requests and not event.pull_requests[0].merged) %}dimmed{% endif %}">
+        {% if event.issue %}
         <details>
           <summary>{{ event.issue.title }}</summary>
           <p>{{ event.issue.body }}</p>
@@ -28,14 +29,9 @@
           </li>
           {% endfor %}
         </ul>
-      </li>
-      {% endfor %}
-    </ul>
-    <h2>Main Trunk Commits Not Associated with a Pull Request</h2>
-    <ul>
-      {% for commit in main_trunk_commits %}
-      <li>
-        {{ commit.committedDate }} - <a href="{{ commit.url }}">{{ commit.message }}</a>
+        {% else %}
+        {{ event.committedDate }} - <a href="{{ event.url }}">{{ event.message }}</a>
+        {% endif %}
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
Related to #52

Merge the lists of `PromptEvents` and `Main Trunk Commits Not Associated With a Pull Request` into a single list.

* Update `scripts/generate_summary.py`:
  - Merge `prompt_events` and `main_trunk_commits` into a single list in the `main` function.
  - Update the `render_template` function to take a single merged list as an argument.
  - Update the `main` function to pass the merged list to the `render_template` function.
* Update `scripts/summary_template.html`:
  - Render the merged list in a single section.
  - Add appropriate formatting for each type of event in the merged list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/53?shareId=70917ff3-9b47-4624-b761-0929e9db0df3).