### PR TITLE
Add progress messages

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -39,6 +39,7 @@ def render_template(events):
 
 
 def get_main_trunk_commits():
+    print("Querying GitHub API for main trunk commits...")
     query = """
     query($cursor: String) {
         repository(owner: "abrie", name: "nl12") {
@@ -89,6 +90,7 @@ def get_main_trunk_commits():
 
 
 def main():
+    print("Querying GitHub API for issues...")
     query = """
     query($cursor: String) {
         repository(owner: "abrie", name: "nl12") {
@@ -154,9 +156,11 @@ def main():
     events = prompt_events + main_trunk_commits
     events.sort(key=lambda x: x.timestamp if isinstance(x, PromptEvent) else x["committedDate"])
     
+    print("Generating template...")
     output = render_template(events)
     with open("index.html", "w") as f:
         f.write(output)
+    print("Summary page generated successfully.")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -158,9 +158,10 @@ def main():
     
     print("Generating template...")
     output = render_template(events)
-    with open("index.html", "w") as f:
+    output_file_path = os.path.abspath("index.html")
+    with open(output_file_path, "w") as f:
         f.write(output)
-    print("Summary page generated successfully.")
+    print(f"Summary page generated successfully. Output file: {output_file_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -80,6 +80,7 @@ def get_main_trunk_commits():
                     "message": commit["message"],
                     "url": commit["url"]
                 })
+        print(f"Processed a page of commits, cursor: {cursor}")
         if not history["pageInfo"]["hasNextPage"]:
             break
         cursor = history["pageInfo"]["endCursor"]
@@ -142,6 +143,7 @@ def main():
                 })
             prompt_event = PromptEvent(issue, pull_requests)
             prompt_events.append(prompt_event)
+        print(f"Processed a page of issues, cursor: {cursor}")
         if not issues["pageInfo"]["hasNextPage"]:
             break
         cursor = issues["pageInfo"]["endCursor"]


### PR DESCRIPTION
Related to #54

Add progress messages to the console for each pagination step in the summary page generation.

* Add `print` statement in `get_main_trunk_commits()` function to log progress messages for each pagination step.
* Add `print` statement in `main()` function to log progress messages for each pagination step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/55?shareId=5d282e58-2523-4376-8dbb-7a082dd25f18).