### PR TITLE
Do not display timestamps for Pull Requests or commits

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -24,13 +24,13 @@
         <ul>
           {% for pr in event.pull_requests %}
           <li class="{% if not pr.merged %}dimmed{% endif %}">
-            {{ pr.createdAt }} - {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
+            {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
             <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}">Branch: {{ pr.branch }}</a>
           </li>
           {% endfor %}
         </ul>
         {% else %}
-        {{ event.committedDate }} - <a href="{{ event.url }}">{{ event.message }}</a>
+        <a href="{{ event.url }}">{{ event.message }}</a>
         {% endif %}
       </li>
       {% endfor %}


### PR DESCRIPTION
Related to #58

Remove timestamps for Pull Requests and commits in the template rendering.

* Remove the `{{ pr.createdAt }}` line from the Pull Request section in `scripts/summary_template.html`.
* Remove the `{{ event.committedDate }}` line from the commit section in `scripts/summary_template.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/60?shareId=d75fa781-541d-4484-a950-57967327a47b).