### PR TITLE
Update the summary template to move the Pull Requests list of a PromptEvent into the <details> section

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -20,15 +20,15 @@
         <details>
           <summary>{{ event.issue.title }}</summary>
           <p>{{ event.issue.body }}</p>
+          <ul>
+            {% for pr in event.pull_requests %}
+            <li class="{% if not pr.merged %}dimmed{% endif %}">
+              {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
+              <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}">Branch: {{ pr.branch }}</a>
+            </li>
+            {% endfor %}
+          </ul>
         </details>
-        <ul>
-          {% for pr in event.pull_requests %}
-          <li class="{% if not pr.merged %}dimmed{% endif %}">
-            {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
-            <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}">Branch: {{ pr.branch }}</a>
-          </li>
-          {% endfor %}
-        </ul>
         {% else %}
         <a href="{{ event.url }}">{{ event.message }}</a>
         {% endif %}


### PR DESCRIPTION
Related to #61

Move the Pull Requests list of a `PromptEvent` inside the `<details>` section in `scripts/summary_template.html`.

* Render the Pull Requests list as an unordered list (`<ul>`) within the `<details>` section.
* Remove the previous rendering of the Pull Requests list outside the `<details>` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/62?shareId=d51cec06-6e7d-4447-a8e6-c1cb82ca6fe1).