### PR TITLE
Use bodyHtml instead of body for body content in Issues and Pull Request

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -104,7 +104,7 @@ def main():
                         title
                         createdAt
                         url
-                        body
+                        bodyHtml
                         timelineItems(itemTypes: CROSS_REFERENCED_EVENT, first: 100) {
                             edges {
                                 node {

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -104,7 +104,7 @@ def main():
                         title
                         createdAt
                         url
-                        bodyHtml
+                        bodyHTML
                         timelineItems(itemTypes: CROSS_REFERENCED_EVENT, first: 100) {
                             edges {
                                 node {

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -19,7 +19,7 @@
         {% if event.issue %}
         <details>
           <summary>{{ event.issue.title }}</summary>
-          <p>{{ event.issue.bodyHtml | safe }}</p>
+          <p>{{ event.issue.bodyHTML | safe }}</p>
           <ul>
             {% for pr in event.pull_requests %}
             <li class="{% if not pr.merged %}dimmed{% endif %}">

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -19,7 +19,7 @@
         {% if event.issue %}
         <details>
           <summary>{{ event.issue.title }}</summary>
-          <p>{{ event.issue.body }}</p>
+          <p>{{ event.issue.bodyHtml | safe }}</p>
           <ul>
             {% for pr in event.pull_requests %}
             <li class="{% if not pr.merged %}dimmed{% endif %}">


### PR DESCRIPTION
Related to #67

Update `scripts/generate_summary.py` and `scripts/summary_template.html` to use `bodyHtml` instead of `body` for issue content.

* **scripts/generate_summary.py**
  - Update the GraphQL query to fetch the `bodyHtml` field instead of `body`.

* **scripts/summary_template.html**
  - Update the template to use `{{ event.issue.bodyHtml | safe }}` instead of `{{ event.issue.body }}`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/68?shareId=7d9ba275-d0a4-43e6-8ecc-a67c4647474e).