### PR TITLE
Use the HTML versions of the headlines and message bodies for commit messages

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -30,7 +30,11 @@
           </ul>
         </details>
         {% else %}
-        <a href="{{ event.url }}">{{ event.message }}</a>
+        <details>
+          <summary>{{ event.headlineHTML | safe }}</summary>
+          <p>{{ event.messageBodyHTML | safe }}</p>
+          <a href="{{ event.url }}">Commit Link</a>
+        </details>
         {% endif %}
       </li>
       {% endfor %}


### PR DESCRIPTION
Related to #69

Update `scripts/summary_template.html` to use HTML versions of commit messages

* Use `event.headlineHTML` for the summary in the `details` element
* Use `event.messageBodyHTML` for the details in the `details` element
* Include a link to the commit using `event.url` in the details

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/70?shareId=c204c8b0-54ac-4033-979f-0b2314b656fd).