### PR TITLE
Use the HTML versions of the headlines and message bodies for commit messages

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -54,7 +54,8 @@ def get_main_trunk_commits():
                             edges {
                                 node {
                                     committedDate
-                                    message
+                                    headlineHTML
+                                    messageBodyHTML
                                     url
                                     associatedPullRequests(first: 1) {
                                         totalCount
@@ -78,7 +79,8 @@ def get_main_trunk_commits():
             if commit["associatedPullRequests"]["totalCount"] == 0:
                 commits.append({
                     "committedDate": commit["committedDate"],
-                    "message": commit["message"],
+                    "headlineHTML": commit["headlineHTML"],
+                    "messageBodyHTML": commit["messageBodyHTML"],
                     "url": commit["url"]
                 })
         print(f"Processed a page of commits, cursor: {cursor}")

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -54,7 +54,7 @@ def get_main_trunk_commits():
                             edges {
                                 node {
                                     committedDate
-                                    headlineHTML
+                                    messageHeadlineHTML
                                     messageBodyHTML
                                     url
                                     associatedPullRequests(first: 1) {
@@ -79,7 +79,7 @@ def get_main_trunk_commits():
             if commit["associatedPullRequests"]["totalCount"] == 0:
                 commits.append({
                     "committedDate": commit["committedDate"],
-                    "headlineHTML": commit["headlineHTML"],
+                    "messageHeadlineHTML": commit["messageHeadlineHTML"],
                     "messageBodyHTML": commit["messageBodyHTML"],
                     "url": commit["url"]
                 })

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -30,7 +30,11 @@
           </ul>
         </details>
         {% else %}
-        <a href="{{ event.url }}">{{ event.message }}</a>
+        <details>
+          <summary>{{ event.headlineHTML | safe }}</summary>
+          <p>{{ event.messageBodyHTML | safe }}</p>
+          <a href="{{ event.url }}">View Commit</a>
+        </details>
         {% endif %}
       </li>
       {% endfor %}

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -31,7 +31,7 @@
         </details>
         {% else %}
         <details>
-          <summary>{{ event.headlineHTML | safe }}</summary>
+          <summary>{{ event.messageHeadlineHTML | safe }}</summary>
           <p>{{ event.messageBodyHTML | safe }}</p>
           <a href="{{ event.url }}">View Commit</a>
         </details>


### PR DESCRIPTION
Related to #69

Update code to fetch the HTML versions of the message headline and bodies via the GraphQL interface and use a details/summary HTML structure to render the commit into the summary list.

* Update the GraphQL query in `scripts/generate_summary.py` to fetch `headlineHTML` and `messageBodyHTML` for commits.
* Update the `get_main_trunk_commits` function in `scripts/generate_summary.py` to include `headlineHTML` and `messageBodyHTML` in the commit data.
* Update the `main` function in `scripts/generate_summary.py` to handle the new commit data fields.
* Update the template in `scripts/summary_template.html` to use a details/summary HTML structure for commit messages.
* Use `headlineHTML` for the summary and `messageBodyHTML` for the details, along with a link to the commit in `scripts/summary_template.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/71?shareId=f88acc6e-103e-4b00-94e5-849de3e906af).