### PR TITLE
Include a commit id for each PromptEvent or CommitEvent

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,17 @@
 .dimmed {
   opacity: 0.5;
 }
+
+.copy-button {
+  background-color: #4CAF50;
+  border: none;
+  color: white;
+  padding: 5px 10px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 12px;
+  margin: 4px 2px;
+  cursor: pointer;
+  border-radius: 4px;
+}

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -20,6 +20,17 @@ class PromptEvent:
         else:
             return self.issue["createdAt"]
 
+    def get_git_command(self):
+        if self.state == "Merged":
+            merged_prs = [pr for pr in self.pull_requests if pr["merged"]]
+            commit_id = merged_prs[0]["commitId"]
+            return f"git checkout {commit_id}"
+        else:
+            return None
+
+    def get_copy_button(self):
+        return '<button onclick="copyToClipboard()">Copy</button>'
+
 
 def query_github(query, variables=None):
     headers = {"Authorization": f"Bearer {GITHUB_TOKEN}"}
@@ -143,7 +154,8 @@ def query_issues_and_prs():
                 pull_requests.append({
                     "createdAt": pr["createdAt"],
                     "merged": pr["merged"],
-                    "branch": pr["headRefName"]
+                    "branch": pr["headRefName"],
+                    "commitId": pr["commitId"]
                 })
             prompt_event = PromptEvent(issue, pull_requests)
             prompt_events.append(prompt_event)

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -9,6 +9,19 @@
       ul, li {
         list-style-type: none;
       }
+      .copy-button {
+        background-color: #4CAF50;
+        border: none;
+        color: white;
+        padding: 5px 10px;
+        text-align: center;
+        text-decoration: none;
+        display: inline-block;
+        font-size: 12px;
+        margin: 4px 2px;
+        cursor: pointer;
+        border-radius: 4px;
+      }
     </style>
   </head>
   <body>
@@ -25,6 +38,10 @@
             <li class="{% if not pr.merged %}dimmed{% endif %}">
               {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
               <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}">Branch: {{ pr.branch }}</a>
+              {% if pr.merged %}
+              <p>Git Command: {{ event.get_git_command() }}</p>
+              <button class="copy-button" onclick="copyToClipboard('{{ event.get_git_command() }}')">Copy</button>
+              {% endif %}
             </li>
             {% endfor %}
           </ul>
@@ -34,10 +51,21 @@
           <summary>{{ event.messageHeadlineHTML | safe }}</summary>
           <p>{{ event.messageBodyHTML | safe }}</p>
           <a href="{{ event.url }}">View Commit</a>
+          <p>Git Command: {{ event.get_git_command() }}</p>
+          <button class="copy-button" onclick="copyToClipboard('{{ event.get_git_command() }}')">Copy</button>
         </details>
         {% endif %}
       </li>
       {% endfor %}
     </ul>
+    <script>
+      function copyToClipboard(text) {
+        navigator.clipboard.writeText(text).then(function() {
+          console.log('Copying to clipboard was successful!');
+        }, function(err) {
+          console.error('Could not copy text: ', err);
+        });
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Related to #77

Add git command and copy-to-clipboard button for each `PromptEvent` or `CommitEvent`.

* Modify `scripts/generate_summary.py` to include methods for generating git command and copy-to-clipboard button.
* Update `scripts/summary_template.html` to display git command and copy-to-clipboard button for each `PromptEvent` or `CommitEvent`.
* Add styles for the copy-to-clipboard button in `public/styles.css`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/78?shareId=7f3889dc-5309-4888-978a-9c9969a8567c).