### PR TITLE
Implement git checkout for PromptEvent and CommitEvent

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -28,12 +28,20 @@
             </li>
             {% endfor %}
           </ul>
+          {% if event.commit_hash %}
+          <p>Git Command: <code>{{ event.git_command }}</code></p>
+          <button onclick="navigator.clipboard.writeText('{{ event.git_command }}')">Copy Command</button>
+          {% endif %}
         </details>
         {% else %}
         <details>
           <summary>{{ event.messageHeadlineHTML | safe }}</summary>
           <p>{{ event.messageBodyHTML | safe }}</p>
           <a href="{{ event.url }}">View Commit</a>
+          {% if event.commit_hash %}
+          <p>Git Command: <code>{{ event.git_command }}</code></p>
+          <button onclick="navigator.clipboard.writeText('{{ event.git_command }}')">Copy Command</button>
+          {% endif %}
         </details>
         {% endif %}
       </li>


### PR DESCRIPTION
Related to #77

Add functionality to check out the source tree at the point referenced by each `PromptEvent` or `CommitEvent`.

* Add a `commit_hash` attribute to the `PromptEvent` class in `scripts/generate_summary.py` to store the commit hash.
* Modify the `get_main_trunk_commits` function in `scripts/generate_summary.py` to include commit hashes in the returned commits.
* Generate git commands for checking out specific commits in the `render_template` function in `scripts/generate_summary.py`.
* Add a section to display the git command for each `PromptEvent` and `CommitEvent` in `scripts/summary_template.html`.
* Add a button to copy the git command to the clipboard for each `PromptEvent` and `CommitEvent` in `scripts/summary_template.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/79?shareId=ee14ce41-39ff-4731-8632-50c0e314cbe0).