### PR TITLE
Refactor to add Headline and Body getters to PromptEvent and CommitEvent

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -20,6 +20,16 @@ class PromptEvent:
         else:
             return self.issue["createdAt"]
 
+    @property
+    def Headline(self):
+        return self.issue["title"]
+
+    @property
+    def Body(self):
+        body = self.issue["bodyHTML"]
+        pr_summaries = "\n".join([f"<p>{pr['title']}</p>" for pr in self.pull_requests])
+        return f"{body}\n{pr_summaries}"
+
 
 class CommitEvent:
     def __init__(self, commit):
@@ -32,6 +42,14 @@ class CommitEvent:
 
     def get_commit_hash(self):
         return self.commit["url"].split("/")[-1]
+
+    @property
+    def Headline(self):
+        return self.commit["messageHeadlineHTML"]
+
+    @property
+    def Body(self):
+        return self.commit["messageBodyHTML"]
 
 
 def query_github(query, variables=None):

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -18,8 +18,8 @@
       <li class="{% if event.state == 'Unmerged' or (event.pull_requests and not event.pull_requests[0].merged) %}dimmed{% endif %}">
         {% if event.issue %}
         <details>
-          <summary>{{ event.issue.title }}</summary>
-          <p>{{ event.issue.bodyHTML | safe }}</p>
+          <summary>{{ event.Headline }}</summary>
+          <p>{{ event.Body | safe }}</p>
           <ul>
             {% for pr in event.pull_requests %}
             <li class="{% if not pr.merged %}dimmed{% endif %}">
@@ -31,8 +31,8 @@
         </details>
         {% else %}
         <details>
-          <summary>{{ event.messageHeadlineHTML | safe }}</summary>
-          <p>{{ event.messageBodyHTML | safe }}</p>
+          <summary>{{ event.Headline | safe }}</summary>
+          <p>{{ event.Body | safe }}</p>
           <a href="{{ event.url }}">View Commit</a>
         </details>
         {% endif %}


### PR DESCRIPTION
Related to #82

Add Headline and Body getters to `PromptEvent` and `CommitEvent` classes.

* Add a Headline getter to the `PromptEvent` class that returns the issue title.
* Add a Body getter to the `PromptEvent` class that returns the issue bodyHTML and includes PR summaries.
* Add a Headline getter to the `CommitEvent` class that returns the messageHeadlineHTML.
* Add a Body getter to the `CommitEvent` class that returns the messageBodyHTML.
* Update `summary_template.html` to use the Headline and Body getters to fill the `<summary>` and `<p>` sections respectively.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/83?shareId=01800a7f-9166-4417-a0aa-c803779dc9cf).