### PR TITLE
Refactor template to use macros for CommitEvent and PromptEvent

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -14,27 +14,35 @@
   <body>
     <h1>Summary of Significant Activity</h1>
     <ul>
+      {% macro commit_event_macro(event) %}
+      <details>
+        <summary>{{ event.messageHeadlineHTML | safe }}</summary>
+        <p>{{ event.messageBodyHTML | safe }}</p>
+        <a href="{{ event.url }}">View Commit</a>
+      </details>
+      {% endmacro %}
+
+      {% macro prompt_event_macro(event) %}
+      <details>
+        <summary>{{ event.issue.title }}</summary>
+        <p>{{ event.issue.bodyHTML | safe }}</p>
+        <ul>
+          {% for pr in event.pull_requests %}
+          <li class="{% if not pr.merged %}dimmed{% endif %}">
+            {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
+            <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}">Branch: {{ pr.branch }}</a>
+          </li>
+          {% endfor %}
+        </ul>
+      </details>
+      {% endmacro %}
+
       {% for event in events %}
       <li class="{% if event.state == 'Unmerged' or (event.pull_requests and not event.pull_requests[0].merged) %}dimmed{% endif %}">
         {% if event.issue %}
-        <details>
-          <summary>{{ event.issue.title }}</summary>
-          <p>{{ event.issue.bodyHTML | safe }}</p>
-          <ul>
-            {% for pr in event.pull_requests %}
-            <li class="{% if not pr.merged %}dimmed{% endif %}">
-              {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
-              <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}">Branch: {{ pr.branch }}</a>
-            </li>
-            {% endfor %}
-          </ul>
-        </details>
+          {{ prompt_event_macro(event) }}
         {% else %}
-        <details>
-          <summary>{{ event.messageHeadlineHTML | safe }}</summary>
-          <p>{{ event.messageBodyHTML | safe }}</p>
-          <a href="{{ event.url }}">View Commit</a>
-        </details>
+          {{ commit_event_macro(event) }}
         {% endif %}
       </li>
       {% endfor %}


### PR DESCRIPTION
Related to #84

Refactor the template in `scripts/summary_template.html` to use macros for rendering `CommitEvent` and `PromptEvent`.

* Add `commit_event_macro` macro to encapsulate the rendering logic for `CommitEvent`.
* Add `prompt_event_macro` macro to encapsulate the rendering logic for `PromptEvent`.
* Update the main template to call `commit_event_macro` and `prompt_event_macro` macros for rendering `CommitEvent` and `PromptEvent`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/85?shareId=dff14db9-16a4-40c1-8f6a-6cd410c9f1b5).