### PR TITLE
Add headline and body fields to PromptEvent

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -12,6 +12,8 @@ class PromptEvent:
         self.pull_requests = pull_requests
         self.state = "Merged" if any(pr["merged"] for pr in pull_requests) else "Unmerged"
         self.timestamp = self.get_timestamp()
+        self.headline = issue['titleHTML']
+        self.body = issue['bodyHTML']
 
     def get_timestamp(self):
         if self.state == "Merged":

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -118,10 +118,10 @@ def query_issues_and_prs():
                 }
                 edges {
                     node {
-                        title
                         createdAt
                         url
                         bodyHTML
+                        titleHTML
                         timelineItems(itemTypes: CROSS_REFERENCED_EVENT, first: 100) {
                             edges {
                                 node {

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -24,8 +24,8 @@
 
       {% macro prompt_event_macro(event) %}
       <details>
-        <summary>{{ event.issue.title }}</summary>
-        <p>{{ event.issue.bodyHTML | safe }}</p>
+        <summary>{{ event.headline | safe }}</summary>
+        <p>{{ event.body | safe }}</p>
         <ul>
           {% for pr in event.pull_requests %}
           <li class="{% if not pr.merged %}dimmed{% endif %}">


### PR DESCRIPTION
Related to #88

Add `headline` and `body` fields to `PromptEvent` and update template references

* Add `headline` and `body` fields to the `PromptEvent` class in `scripts/generate_summary.py`
* Set `self.headline` to `issue['titleHTML']` and `self.body` to `issue['bodyHTML']` in the `__init__` method of `PromptEvent`
* Update references to `event.issue.title` to use `event.headline` in `scripts/summary_template.html`
* Update references to `event.issue.bodyHTML` to use `event.body` in `scripts/summary_template.html`
* Pipe `event.headline` through 'safe' filter in the template

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/89?shareId=08e0523a-179a-4619-8575-a12bd805af5e).