### PR TITLE
Append the abbreviatedOid to the headline for PromptEvents and Commit Events

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -16,7 +16,7 @@
     <ul>
       {% macro commit_event_macro(event) %}
       <details>
-        <summary>{{ event.headline | safe }}</summary>
+        <summary>{{ event.headline | safe }} <span onclick="copyToClipboard('{{ event.abbreviatedOid }}')">{{ event.abbreviatedOid }}</span></summary>
         <p>{{ event.body | safe }}</p>
         <a href="{{ event.url }}">View Commit</a>
       </details>
@@ -24,7 +24,7 @@
 
       {% macro prompt_event_macro(event) %}
       <details>
-        <summary>{{ event.headline | safe }}</summary>
+        <summary>{{ event.headline | safe }} <span onclick="copyToClipboard('{{ event.abbreviatedOid }}')">{{ event.abbreviatedOid }}</span></summary>
         <p>{{ event.body | safe }}</p>
         <ul>
           {% for pr in event.pull_requests %}
@@ -47,5 +47,14 @@
       </li>
       {% endfor %}
     </ul>
+    <script>
+      function copyToClipboard(text) {
+        navigator.clipboard.writeText(text).then(function() {
+          console.log('Copied to clipboard successfully!');
+        }, function(err) {
+          console.error('Could not copy text: ', err);
+        });
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Related to #94

Append the abbreviatedOid to the headline for PromptEvents and Commit Events.

* Modify `commit_event_macro` in `scripts/summary_template.html` to append `abbreviatedOid` to the headline.
* Modify `prompt_event_macro` in `scripts/summary_template.html` to append `abbreviatedOid` to the headline.
* Add `onclick` event to `abbreviatedOid` in `scripts/summary_template.html` to copy it to the clipboard.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/95?shareId=e885f61c-6df2-4dd3-8e7e-2e2474bf4bd4).