### PR TITLE
Use the merged commit (if any) in a PromptEvent to assign the abbreviatedOid and oid to the PromptEvent

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -14,8 +14,9 @@ class PromptEvent:
         self.timestamp = self.get_timestamp()
         self.headline = issue['titleHTML']
         self.body = issue['bodyHTML']
-        self.oid = issue['mergeCommit']['oid'] if 'mergeCommit' in issue else None
-        self.abbreviatedOid = issue['mergeCommit']['abbreviatedOid'] if 'mergeCommit' in issue else None
+        merged_prs = [pr for pr in pull_requests if pr["merged"]]
+        self.oid = merged_prs[0]["oid"] if merged_prs else None
+        self.abbreviatedOid = merged_prs[0]["abbreviatedOid"] if merged_prs else None
 
     def get_timestamp(self):
         if self.state == "Merged":

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -16,7 +16,7 @@
     <ul>
       {% macro commit_event_macro(event) %}
       <details>
-        <summary>{{ event.headline | safe }}</summary>
+        <summary>{{ event.headline | safe }} ({{ event.abbreviatedOid }})</summary>
         <p>{{ event.body | safe }}</p>
         <a href="{{ event.url }}">View Commit</a>
       </details>
@@ -24,7 +24,7 @@
 
       {% macro prompt_event_macro(event) %}
       <details>
-        <summary>{{ event.headline | safe }}</summary>
+        <summary>{{ event.headline | safe }} ({{ event.abbreviatedOid }})</summary>
         <p>{{ event.body | safe }}</p>
         <ul>
           {% for pr in event.pull_requests %}


### PR DESCRIPTION
Related to #97

Update `PromptEvent` class to assign `oid` and `abbreviatedOid` from the first merged pull request if it exists.

* Modify `scripts/generate_summary.py` to retrieve `oid` and `abbreviatedOid` from the `mergeCommit` of the first merged pull request and assign them to the `PromptEvent`.
* Show the `abbreviatedOid` at the end of the `<summary>` section of each `PromptEvent` and `CommitEvent` in `scripts/summary_template.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/98?shareId=abf8874a-1d84-4667-87f9-aca1446ddaaa).