### PR TITLE
Use the mergeCommit (if any) in a PromptEvent to assign the abbreviatedOid and oid to the PromptEvent

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -14,8 +14,13 @@ class PromptEvent:
         self.timestamp = self.get_timestamp()
         self.headline = issue['titleHTML']
         self.body = issue['bodyHTML']
-        self.oid = issue['mergeCommit']['oid'] if 'mergeCommit' in issue else None
-        self.abbreviatedOid = issue['mergeCommit']['abbreviatedOid'] if 'mergeCommit' in issue else None
+        self.oid = None
+        self.abbreviatedOid = None
+        for pr in pull_requests:
+            if pr["merged"] and "mergeCommit" in pr:
+                self.oid = pr["mergeCommit"]["oid"]
+                self.abbreviatedOid = pr["mergeCommit"]["abbreviatedOid"]
+                break
 
     def get_timestamp(self):
         if self.state == "Merged":


### PR DESCRIPTION
Related to #97

Update `PromptEvent` class to use `mergeCommit` from merged pull requests to assign `oid` and `abbreviatedOid`.

* Set `oid` and `abbreviatedOid` to `None` initially.
* Iterate through pull requests to find the merged one with a `mergeCommit`.
* Assign `oid` and `abbreviatedOid` from the `mergeCommit` of the merged pull request.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/99?shareId=ad67aa23-bd94-4e91-89ac-9a898aac6cc4).