### PR TITLE
Display abbreviatedOid at the end of summary section for each PromptEvent and CommitEvent

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,8 @@
 .dimmed {
   opacity: 0.5;
 }
+
+.abbreviated-oid {
+  font-family: monospace;
+  font-size: small;
+}

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -19,6 +19,7 @@
         <summary>{{ event.headline | safe }}</summary>
         <p>{{ event.body | safe }}</p>
         <a href="{{ event.url }}">View Commit</a>
+        <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
       </details>
       {% endmacro %}
 
@@ -34,6 +35,7 @@
           </li>
           {% endfor %}
         </ul>
+        <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
       </details>
       {% endmacro %}
 


### PR DESCRIPTION
Related to #100

Display `abbreviatedOid` at the end of the summary section for each `PromptEvent` and `CommitEvent` using a small, monospace font.

* Add a new CSS class `.abbreviated-oid` in `public/styles.css` to display text in a small, monospace font.
* Update the `commit_event_macro` in `scripts/summary_template.html` to include the `abbreviatedOid` at the end of the summary section.
* Update the `prompt_event_macro` in `scripts/summary_template.html` to include the `abbreviatedOid` at the end of the summary section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/101?shareId=92f18bf3-5d11-4835-800f-3a0133f18c91).