### PR TITLE
Update template to show abbreviatedOid at the end of the headline

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,8 @@
 .dimmed {
   opacity: 0.5;
 }
+
+.monospace-small {
+  font-family: monospace;
+  font-size: small;
+}

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -16,7 +16,7 @@
     <ul>
       {% macro commit_event_macro(event) %}
       <details>
-        <summary>{{ event.headline | safe }}</summary>
+        <summary>{{ event.headline | safe }} <span class="monospace-small">{{ event.abbreviatedOid }}</span></summary>
         <p>{{ event.body | safe }}</p>
         <a href="{{ event.url }}">View Commit</a>
       </details>
@@ -24,7 +24,7 @@
 
       {% macro prompt_event_macro(event) %}
       <details>
-        <summary>{{ event.headline | safe }}</summary>
+        <summary>{{ event.headline | safe }} <span class="monospace-small">{{ event.abbreviatedOid }}</span></summary>
         <p>{{ event.body | safe }}</p>
         <ul>
           {% for pr in event.pull_requests %}


### PR DESCRIPTION
Related to #102

Add the abbreviatedOid to the headline for PromptEvents and CommitEvents in the template

* Update `scripts/summary_template.html` to include `event.abbreviatedOid` at the end of the headline for `PromptEvents` and `CommitEvents` using the `.monospace-small` class
* Add a new CSS class `.monospace-small` in `public/styles.css` with `font-family: monospace` and `font-size: small`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/103?shareId=244a532e-f358-4fc4-a597-cdbc9696dcbf).