### PR TITLE
Build the target project at each significant event

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -20,6 +20,7 @@
         <p>{{ event.body | safe }}</p>
         <a href="{{ event.url }}">View Commit</a>
         <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
+        <a href="/builds/{{ event.abbreviatedOid }}">View Build</a>
       </details>
       {% endmacro %}
 
@@ -36,6 +37,7 @@
           {% endfor %}
         </ul>
         <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
+        <a href="/builds/{{ event.abbreviatedOid }}">View Build</a>
       </details>
       {% endmacro %}
 


### PR DESCRIPTION
Related to #104

Add logic to build the `abrie/nl12` project for each significant event and include links to the builds in the summary.

* Modify `scripts/generate_summary.py`:
  - Clone the `abrie/nl12` repository into a temporary location.
  - Create a 'builds' folder in the local directory.
  - For each PromptEvent with a merged Pull Request and each CommitEvent, check out the associated `oid` from the 'abrie/nl12' repository in the temporary location.
  - Remove all files and folders that are not part of the source tree.
  - Invoke 'yarn install' to install dependencies.
  - Invoke 'npx vite build' to build the project.
  - Move the contents of the 'dist' folder into a folder named after the abbreviatedOid and place it into the 'builds' folder.
  - Log any errors that occur during the build and continue to the next event.

* Modify `scripts/summary_template.html`:
  - Add a link to the folder named after the abbreviatedOid in the 'builds' folder for each PromptEvent and CommitEvent.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/106?shareId=e2c9e279-8419-426b-92e3-9c80a2c56695).