### PR TITLE
If a build fails, do not show a link

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -21,7 +21,7 @@ class PromptEvent:
         self.body = issue['bodyHTML']
         self.oid = None
         self.abbreviatedOid = None
-        self.build_success = False  # P85c5
+        self.build_success = False
         for pr in pull_requests:
             if pr["oid"]:
                 self.oid = pr["oid"]
@@ -45,7 +45,7 @@ class CommitEvent:
         self.body = commit['messageBodyHTML']
         self.oid = commit.get('oid')
         self.abbreviatedOid = commit.get('abbreviatedOid')
-        self.build_success = False  # P85c5
+        self.build_success = False
 
     def get_timestamp(self):
         return self.commit["committedDate"]
@@ -215,7 +215,7 @@ def build_project(oid, abbreviatedOid):
             ["npx", "vite", "build", "--base", "./", "--logLevel", "silent"], cwd=temp_dir)
         if result.returncode != 0:
             print(f"Build failed for {abbreviatedOid}")
-            return False  # Pd3dc
+            return False
         build_dir = os.path.join("builds", abbreviatedOid)
         os.makedirs(build_dir, exist_ok=True)
         dist_dir = os.path.join(temp_dir, "dist")
@@ -226,7 +226,7 @@ def build_project(oid, abbreviatedOid):
                 shutil.copytree(s, d, dirs_exist_ok=True)
             else:
                 shutil.copy2(s, d)
-        return True  # Pd3dc
+        return True
     finally:
         shutil.rmtree(temp_dir)
 
@@ -248,9 +248,9 @@ def main():
         os.makedirs("builds", exist_ok=True)
         for event in events:
             if isinstance(event, PromptEvent) and event.state == "Merged":
-                event.build_success = build_project(event.oid, event.abbreviatedOid)  # Pace2
+                event.build_success = build_project(event.oid, event.abbreviatedOid)
             elif isinstance(event, CommitEvent):
-                event.build_success = build_project(event.oid, event.abbreviatedOid)  # Pace2
+                event.build_success = build_project(event.oid, event.abbreviatedOid)
 
     print("Generating template...")
     output = render_template(events)

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -40,7 +40,7 @@
           {% endfor %}
         </ul>
         <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
-        {% if event.build_success %}
+        {% if event.build_success and event.state == "Merged" %}
         <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
         {% endif %}
       </details>

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -21,7 +21,9 @@
         <p>{{ event.body | safe }}</p>
         <a href="{{ event.url }}">View Commit</a>
         <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
+        {% if event.build_success %}
         <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
+        {% endif %}
       </details>
       {% endmacro %} {% macro prompt_event_macro(event) %}
       <details>
@@ -38,7 +40,9 @@
           {% endfor %}
         </ul>
         <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
+        {% if event.build_success %}
         <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
+        {% endif %}
       </details>
       {% endmacro %} {% for event in events %}
       <li


### PR DESCRIPTION
Related to #116

Add conditional display of "View Build" link based on build success.

* Add `build_success` attribute to `PromptEvent` and `CommitEvent` classes in `scripts/generate_summary.py`.
* Modify `build_project` function to return a boolean indicating build success or failure.
* Update `main` function to set the `build_success` attribute based on the result of `build_project`.
* Conditionally show the "View Build" link in `scripts/summary_template.html` only if the `build_success` attribute is `True`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/117?shareId=906fd314-275c-4c8e-8378-b9fd4d1ae7b9).