### PR TITLE
Add a task to move the builds/ folder to the dist/ folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "package-deployment": "mv builds/ dist/"
   },
   "devDependencies": {
     "typescript": "~5.6.2",


### PR DESCRIPTION
Related to #118

Add a new task to the `package.json` file to move the `builds/` folder to the `dist/` folder.

* Add a new script named 'package-deployment' to the `scripts` section
* Set the value of the 'package-deployment' script to `mv builds/ dist/`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/issues/118?shareId=XXXX-XXXX-XXXX-XXXX).