### PR TITLE
Add builds folder to vite configuration

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: "./",
+  publicDir: 'builds/'
+});


### PR DESCRIPTION
Related to #124

Add `builds/` folder to the Vite configuration to be accessible on the dev server.

* Add `publicDir` option in `vite.config.js` to serve `builds/` folder as a static asset.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/125?shareId=8d00bda8-60c1-4362-8520-3d45df6ee3eb).