### PR TITLE
Update generate_summary script to have a configurable build output folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build --base './'",
     "preview": "vite preview",
-    "generate-summary": "python scripts/generate_summary.py --build-significant-steps",
+    "generate-summary": "python scripts/generate_summary.py --build-significant-steps builds/",
     "build-all": "yarn generate-summary && yarn build && mv builds/ dist/"
   },
   "devDependencies": {

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -207,7 +207,7 @@ def query_issues_and_prs():
     return prompt_events
 
 
-def build_project(oid, abbreviatedOid):
+def build_project(oid, abbreviatedOid, build_output_folder):
     repo_dir = "nl12_repo"
     if not os.path.exists(repo_dir):
         subprocess.run(
@@ -225,7 +225,7 @@ def build_project(oid, abbreviatedOid):
         if result.returncode != 0:
             print(f"Build failed for {abbreviatedOid}")
             return False
-        build_dir = os.path.join("builds", abbreviatedOid)
+        build_dir = os.path.join(build_output_folder, abbreviatedOid)
         os.makedirs(build_dir, exist_ok=True)
         dist_dir = os.path.join(temp_dir, "dist")
         for item in os.listdir(dist_dir):
@@ -242,8 +242,8 @@ def build_project(oid, abbreviatedOid):
 
 def main():
     parser = argparse.ArgumentParser(description="Generate summary")
-    parser.add_argument("--build-significant-steps", action="store_true",
-                        help="Toggle building of significant steps")
+    parser.add_argument("--build-significant-steps", type=str,
+                        help="Specify the build output folder")
     parser.add_argument("--cache-file", type=str, help="Specify the cache file")
     args = parser.parse_args()
 
@@ -260,12 +260,12 @@ def main():
         x, PromptEvent) else x.timestamp)
 
     if args.build_significant_steps:
-        os.makedirs("builds", exist_ok=True)
+        os.makedirs(args.build_significant_steps, exist_ok=True)
         for event in events:
             if isinstance(event, PromptEvent) and event.state == "Merged":
-                event.build_success = build_project(event.oid, event.abbreviatedOid)
+                event.build_success = build_project(event.oid, event.abbreviatedOid, args.build_significant_steps)
             elif isinstance(event, CommitEvent):
-                event.build_success = build_project(event.oid, event.abbreviatedOid)
+                event.build_success = build_project(event.oid, event.abbreviatedOid, args.build_significant_steps)
 
     print("Generating template...")
     output = render_template(events)


### PR DESCRIPTION
Related to #126

Update the `generate_summary.py` script to accept a configurable build output folder.

* Modify the `--build-significant-steps` argument to accept a path instead of a boolean flag.
* Update the `main` function to handle the new path argument and use it as the build output folder.
* Update the `build_project` function to use the specified build output folder instead of the hardcoded `builds` folder.
* Update the `generate-summary` script in `package.json` to pass the desired build output folder path as an argument to the `generate_summary.py` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/127?shareId=1da4123b-0d2e-431e-ad75-c7360b6a68e2).