### PR TITLE
Add CLI argument to configure repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build --base './'",
     "preview": "vite preview",
-    "generate": "python scripts/generate_summary.py --build-significant-steps public/builds/"
+    "generate": "python scripts/generate_summary.py --repository abrie/nl12 --build-significant-steps public/builds/"
   },
   "devDependencies": {
     "typescript": "~5.6.2",


### PR DESCRIPTION
Related to #129

Add a CLI argument to configure the repository used to generate the summary.

* Update `scripts/generate_summary.py` to accept a `--repository` argument in the format `owner/repo`.
* Parse the repository argument to extract the owner and repo name.
* Update `get_main_trunk_commits`, `query_issues_and_prs`, and `build_project` functions to use the specified repository.
* Update the `generate` script in `package.json` to include the new `--repository` argument.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/130?shareId=17247431-7826-4070-a8dc-03d0cd888e7f).