### PR TITLE
Refactor PromptEvent to use merged boolean

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -17,8 +17,7 @@ class PromptEvent:
     def __init__(self, issue, pull_requests):
         self.issue = issue
         self.pull_requests = pull_requests
-        self.state = "Merged" if any(pr["merged"]
-                                     for pr in pull_requests) else "Unmerged"
+        self.merged = any(pr["merged"] for pr in pull_requests)
         self.timestamp = self.get_timestamp()
         self.headline = issue['titleHTML']
         self.body = issue['bodyHTML']
@@ -32,7 +31,7 @@ class PromptEvent:
                 break
 
     def get_timestamp(self):
-        if self.state == "Merged":
+        if self.merged:
             merged_prs = [pr for pr in self.pull_requests if pr["merged"]]
             return min(pr["createdAt"] for pr in merged_prs)
         else:
@@ -269,7 +268,7 @@ def main():
     if args.build_significant_steps:
         os.makedirs(args.build_significant_steps, exist_ok=True)
         for event in events:
-            if isinstance(event, PromptEvent) and event.state == "Merged":
+            if isinstance(event, PromptEvent) and event.merged:
                 event.build_success = build_project(
                     owner, repo, event.oid, event.abbreviatedOid, args.build_significant_steps)
             elif isinstance(event, CommitEvent):

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -40,13 +40,13 @@
           {% endfor %}
         </ul>
         <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
-        {% if event.build_success and event.state == "Merged" %}
+        {% if event.build_success and event.merged %}
         <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
         {% endif %}
       </details>
       {% endmacro %} {% for event in events %}
       <li
-        class="{% if event.state == 'Unmerged' or (event.pull_requests and not event.pull_requests[0].merged) %}dimmed{% endif %}"
+        class="{% if not event.merged %}dimmed{% endif %}"
       >
         {% if event.issue %} {{ prompt_event_macro(event) }} {% else %} {{
         commit_event_macro(event) }} {% endif %}

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -12,42 +12,42 @@
       }
     </style>
   </head>
+
+  {% macro commit_event_macro(event) %}
+  <details>
+    <summary>{{ event.headline | safe }}</summary>
+    <p>{{ event.body | safe }}</p>
+    <a href="{{ event.url }}">View Commit</a>
+    <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
+    {% if event.build_success %}
+    <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
+    {% endif %}
+  </details>
+  {% endmacro %} {% macro prompt_event_macro(event) %}
+  <details class="{% if not event.merged %}dimmed{% endif %}">
+    <summary>{{ event.headline | safe }}</summary>
+    <p>{{ event.body | safe }}</p>
+    <ul>
+      {% for pr in event.pull_requests %}
+      <li class="{% if not pr.merged %}dimmed{% endif %}">
+        {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
+        <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}"
+          >Branch: {{ pr.branch }}</a
+        >
+      </li>
+      {% endfor %}
+    </ul>
+    <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
+    {% if event.build_success and event.merged %}
+    <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
+    {% endif %}
+  </details>
+  {% endmacro %}
   <body>
     <h1>Summary of Significant Activity</h1>
     <ul>
-      {% macro commit_event_macro(event) %}
-      <details>
-        <summary>{{ event.headline | safe }}</summary>
-        <p>{{ event.body | safe }}</p>
-        <a href="{{ event.url }}">View Commit</a>
-        <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
-        {% if event.build_success %}
-        <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
-        {% endif %}
-      </details>
-      {% endmacro %} {% macro prompt_event_macro(event) %}
-      <details>
-        <summary>{{ event.headline | safe }}</summary>
-        <p>{{ event.body | safe }}</p>
-        <ul>
-          {% for pr in event.pull_requests %}
-          <li class="{% if not pr.merged %}dimmed{% endif %}">
-            {% if pr.merged %}Merged{% else %}Not Merged{% endif %}
-            <a href="https://github.com/abrie/nl12/tree/{{ pr.branch }}"
-              >Branch: {{ pr.branch }}</a
-            >
-          </li>
-          {% endfor %}
-        </ul>
-        <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
-        {% if event.build_success and event.merged %}
-        <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
-        {% endif %}
-      </details>
-      {% endmacro %} {% for event in events %}
-      <li
-        class="{% if not event.merged %}dimmed{% endif %}"
-      >
+      {% for event in events %}
+      <li>
         {% if event.issue %} {{ prompt_event_macro(event) }} {% else %} {{
         commit_event_macro(event) }} {% endif %}
       </li>


### PR DESCRIPTION
Related to #131

Refactor `PromptEvent` class and `summary_template.html` to replace `state` property with `merged` boolean.

* Replace `state` property in `PromptEvent` class with `merged` boolean in `scripts/generate_summary.py`.
* Update `get_timestamp` method in `PromptEvent` class to use `merged` boolean.
* Update conditional display of build link in `scripts/summary_template.html` to use `merged` boolean.
* Update CSS classes and display text for merged and unmerged events using `merged` boolean in `scripts/summary_template.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/132?shareId=af6ff13c-25d7-45a0-8b15-8eac2650eaa7).