### PR TITLE
Do not build a significant step if the abbreviatedOid already exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build --base './'",
     "preview": "vite preview",
-    "generate": "python scripts/generate_summary.py --repository abrie/nl12 --build-significant-steps public/builds/"
+    "generate": "python scripts/generate_summary.py --cache-file cache.json --repository abrie/nl12 --build-significant-steps public/builds/"
   },
   "devDependencies": {
     "typescript": "~5.6.2",

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -209,6 +209,9 @@ def query_issues_and_prs(owner, repo):
 
 
 def build_project(owner, repo, oid, abbreviatedOid, output_folder):
+    if os.path.exists(os.path.join(output_folder, abbreviatedOid)):
+        return True
+
     repo_dir = f"{repo}_repo"
     if not os.path.exists(repo_dir):
         subprocess.run(


### PR DESCRIPTION
Related to #133

Add a check for existing `abbreviatedOid` in `build_project` function in `scripts/generate_summary.py`.

* Check if the `abbreviatedOid` already exists in the output folder before building a significant step.
* Return `True` immediately if the `abbreviatedOid` already exists in the output folder.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/134?shareId=b663b8f6-d4e0-46b1-91a4-1cf100bd3fa2).