### PR TITLE
Refactor the build_project method to not copy the repo_dir into a temp dir

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -216,9 +216,9 @@ def build_project(owner, repo, oid, abbreviatedOid, output_folder):
     if not os.path.exists(repo_dir):
         subprocess.run(
             ["git", "clone", f"https://github.com/{owner}/{repo}.git", repo_dir], check=True)
+    subprocess.run(["git", "clean", "-fdx"], cwd=repo_dir, check=True)
     subprocess.run(["git", "switch", "--detach", oid],
                    cwd=repo_dir, check=True)
-    subprocess.run(["git", "clean", "-fdx"], cwd=repo_dir, check=True)
     subprocess.run(["yarn", "install", "--silent"],
                    cwd=repo_dir, check=True)
     result = subprocess.run(

--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -216,32 +216,27 @@ def build_project(owner, repo, oid, abbreviatedOid, output_folder):
     if not os.path.exists(repo_dir):
         subprocess.run(
             ["git", "clone", f"https://github.com/{owner}/{repo}.git", repo_dir], check=True)
-    temp_dir = tempfile.mkdtemp()
-    try:
-        shutil.copytree(repo_dir, temp_dir, dirs_exist_ok=True)
-        subprocess.run(["git", "switch", "--detach", oid],
-                       cwd=temp_dir, check=True)
-        subprocess.run(["git", "clean", "-fdx"], cwd=temp_dir, check=True)
-        subprocess.run(["yarn", "install", "--silent"],
-                       cwd=temp_dir, check=True)
-        result = subprocess.run(
-            ["npx", "vite", "build", "--base", "./", "--logLevel", "silent"], cwd=temp_dir)
-        if result.returncode != 0:
-            print(f"Build failed for {abbreviatedOid}")
-            return False
-        build_dir = os.path.join(output_folder, abbreviatedOid)
-        os.makedirs(build_dir, exist_ok=True)
-        dist_dir = os.path.join(temp_dir, "dist")
-        for item in os.listdir(dist_dir):
-            s = os.path.join(dist_dir, item)
-            d = os.path.join(build_dir, item)
-            if os.path.isdir(s):
-                shutil.copytree(s, d, dirs_exist_ok=True)
-            else:
-                shutil.copy2(s, d)
-        return True
-    finally:
-        shutil.rmtree(temp_dir)
+    subprocess.run(["git", "switch", "--detach", oid],
+                   cwd=repo_dir, check=True)
+    subprocess.run(["git", "clean", "-fdx"], cwd=repo_dir, check=True)
+    subprocess.run(["yarn", "install", "--silent"],
+                   cwd=repo_dir, check=True)
+    result = subprocess.run(
+        ["npx", "vite", "build", "--base", "./", "--logLevel", "silent"], cwd=repo_dir)
+    if result.returncode != 0:
+        print(f"Build failed for {abbreviatedOid}")
+        return False
+    build_dir = os.path.join(output_folder, abbreviatedOid)
+    os.makedirs(build_dir, exist_ok=True)
+    dist_dir = os.path.join(repo_dir, "dist")
+    for item in os.listdir(dist_dir):
+        s = os.path.join(dist_dir, item)
+        d = os.path.join(build_dir, item)
+        if os.path.isdir(s):
+            shutil.copytree(s, d, dirs_exist_ok=True)
+        else:
+            shutil.copy2(s, d)
+    return True
 
 
 def main():

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -20,7 +20,7 @@
     <a href="{{ event.url }}">View Commit</a>
     <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
     {% if event.build_success %}
-    <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
+    <a href="./builds/{{ event.abbreviatedOid }}/index.html">View Build</a>
     {% endif %}
   </details>
   {% endmacro %} {% macro prompt_event_macro(event) %}
@@ -39,7 +39,7 @@
     </ul>
     <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
     {% if event.build_success and event.merged %}
-    <a href="./builds/{{ event.abbreviatedOid }}">View Build</a>
+    <a href="./builds/{{ event.abbreviatedOid }}/index.html">View Build</a>
     {% endif %}
   </details>
   {% endmacro %}


### PR DESCRIPTION
Related to #135

Refactor the `build_project` method in `scripts/generate_summary.py` to perform all work directly in the `repo_dir` without copying it into a temp dir.

* Remove the creation of a temporary directory using `tempfile.mkdtemp()`.
* Remove the copying of `repo_dir` into the temporary directory.
* Perform the build process directly in the `repo_dir`.
* Remove the deletion of the temporary directory after the build process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/136?shareId=5a3e4dcc-0a9f-478c-a757-edc0852023e0).