### PR TITLE
Redesign the summary template to no longer consist of Summary/Details

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -14,25 +14,25 @@
   </head>
 
   {% macro commit_event_macro(event) %}
-  <details>
-    <summary>{{ event.headline | safe }}</summary>
+  <div class="card bg-white shadow-md rounded-lg p-4 mb-4">
+    <h2 class="text-xl font-bold mb-2">{{ event.headline | safe }}</h2>
     <p>{{ event.body | safe }}</p>
-    <a href="{{ event.url }}">View Commit</a>
+    <a href="{{ event.url }}" class="btn btn-primary mt-4">View Commit</a>
     <span class="abbreviated-oid">{{ event.abbreviatedOid }}</span>
     {% if event.build_success %}
-    <a href="./builds/{{ event.abbreviatedOid }}/index.html">View Build</a>
+    <a href="./builds/{{ event.abbreviatedOid }}/index.html" class="btn btn-primary mt-4">View Build</a>
     {% endif %}
-  </details>
+  </div>
   {% endmacro %} {% macro prompt_event_macro(event) %}
-  <details class="{% if not event.merged %}dimmed{% endif %}">
-    <summary>{{ event.headline | safe }}</summary>
+  <div class="card bg-white shadow-md rounded-lg p-4 mb-4 {% if not event.merged %}opacity-50{% endif %}">
+    <h2 class="text-xl font-bold mb-2">{{ event.headline | safe }}</h2>
     <p>{{ event.body | safe }}</p>
     <div class="pull-request-list">
       <ul>
         {% for pr in event.pull_requests %}
-        <li class="{% if not pr.merged %}dimmed{% endif %}">
-          {% if pr.merged %} - <a href="{{ pr.url }}">Merged</a> {% else %} -
-          <a href="{{ pr.url }}">Unmerged</a>
+        <li class="{% if not pr.merged %}opacity-50{% endif %}">
+          {% if pr.merged %} - <a href="{{ pr.url }}" class="btn btn-primary mt-4">Merged</a> {% else %} -
+          <a href="{{ pr.url }}" class="btn btn-primary mt-4">Unmerged</a>
           {% endif %}
         </li>
         {% endfor %}
@@ -40,22 +40,22 @@
     </div>
     <div class="builds">
       {% if event.build_success and event.merged %}
-      <a href="./builds/{{ event.abbreviatedOid }}/index.html">View Build</a>
+      <a href="./builds/{{ event.abbreviatedOid }}/index.html" class="btn btn-primary mt-4">View Build</a>
       {% else %} No merges and no builds. {% endif %}
     </div>
-  </details>
+  </div>
   {% endmacro %}
 
   <body>
     <h1>Summary of Significant Activity</h1>
-    <ul>
+    <div class="space-y-4">
       {% for event in events %}
-      <li>
+      <div>
         {% if event.issue %} {{ prompt_event_macro(event) }} {% else %} {{
         commit_event_macro(event) }} {% endif %}
-      </li>
+      </div>
       {% endfor %}
-    </ul>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -28,12 +28,19 @@
     <h2 class="text-xl font-bold mb-2">{{ event.headline | safe }}</h2>
     <p>{{ event.body | safe }}</p>
     <div class="pull-request-list">
-      <ul>
-        {% for pr in event.pull_requests %}
-        <li class="{% if not pr.merged %}opacity-50{% endif %}">
-          {% if pr.merged %} - <a href="{{ pr.url }}" class="btn btn-primary mt-4">Merged</a> {% else %} -
+      <h3 class="text-lg font-semibold">Merged Pull Requests</h3>
+      <ul class="bg-green-100 border border-green-200 p-2 rounded">
+        {% for pr in event.pull_requests if pr.merged %}
+        <li>
+          <a href="{{ pr.url }}" class="btn btn-primary mt-4">Merged</a>
+        </li>
+        {% endfor %}
+      </ul>
+      <h3 class="text-lg font-semibold mt-4">Unmerged Pull Requests</h3>
+      <ul class="bg-red-100 border border-red-200 p-2 rounded">
+        {% for pr in event.pull_requests if not pr.merged %}
+        <li>
           <a href="{{ pr.url }}" class="btn btn-primary mt-4">Unmerged</a>
-          {% endif %}
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
Related to #141

Redesign the summary template to use card layouts with Tailwind CSS.

* Replace `<details>` and `<summary>` tags with `<div>` elements to create card layouts using Tailwind CSS classes.
* Add interactive elements like buttons or links for viewing the commit or build at the bottom of each card using Tailwind CSS classes like `btn`, `btn-primary`, and `mt-4`.
* Stack the cards from earliest to latest.
* Position the headline at the top of each entry in a card format.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/145?shareId=0341603c-ea86-4515-ac92-a9a1621401f9).