### PR TITLE
Show more information about referenced Pull Requests in a PromptEvent

### DIFF
--- a/scripts/generate_summary.py
+++ b/scripts/generate_summary.py
@@ -175,6 +175,13 @@ def query_issues_and_prs(owner, repo):
                                                     oid
                                                     abbreviatedOid
                                                 }
+                                                comments(first: 10) {
+                                                    edges {
+                                                        node {
+                                                            bodyText
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -198,13 +205,16 @@ def query_issues_and_prs(owner, repo):
             pull_requests = []
             for pr_edge in issue["timelineItems"]["edges"]:
                 pr = pr_edge["node"]["source"]
+                comments = [comment["node"]["bodyText"]
+                            for comment in pr["comments"]["edges"]]
                 pull_requests.append({
                     "createdAt": pr["createdAt"],
                     "merged": pr["merged"],
                     "branch": pr["headRefName"],
                     "oid": pr["mergeCommit"]["oid"] if pr["merged"] else None,
                     "abbreviatedOid": pr["mergeCommit"]["abbreviatedOid"] if pr["merged"] else None,
-                    "url": pr["url"]
+                    "url": pr["url"],
+                    "comments": comments
                 })
             prompt_event = PromptEvent(issue, pull_requests)
             prompt_events.append(prompt_event)

--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -40,6 +40,11 @@
           <a href="{{ pr.url }}" class="text-blue-500">Merged</a> {% else %} -
           <a href="{{ pr.url }}" class="text-blue-500">Unmerged</a>
           {% endif %}
+          <ul>
+            {% for comment in pr.comments %}
+            <li>{{ comment }}</li>
+            {% endfor %}
+          </ul>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
Related to #154

Add comments from Pull Requests to PromptEvent and display them in the summary template.

* Add a `comments` field to the `pull_requests` list in the `PromptEvent` class in `scripts/generate_summary.py`.
* Update the `query_issues_and_prs` function in `scripts/generate_summary.py` to fetch comments from the Pull Requests and include them in the `pull_requests` list.
* Update the `prompt_event_macro` in `scripts/summary_template.html` to display the term 'Merged' or 'Unmerged' along with the text from the comments in the Pull Request.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/issues/154?shareId=XXXX-XXXX-XXXX-XXXX).