### PR TITLE
Show more information about referenced Pull Requests in a PromptEvent

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -40,6 +40,11 @@
           <a href="{{ pr.url }}" class="text-blue-500">Merged</a> {% else %} -
           <a href="{{ pr.url }}" class="text-blue-500">Unmerged</a>
           {% endif %}
+          <ul class="ml-5 list-disc">
+            {% for comment in pr.comments[:5] %}
+            <li>{{ comment }}</li>
+            {% endfor %}
+          </ul>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
Related to #154

Add comments to PromptEvent and display them in the summary template

* Add `comments` attribute to `PromptEvent` class in `scripts/generate_summary.py` to store text from comments in Pull Request.
* Modify `query_issues_and_prs` function in `scripts/generate_summary.py` to fetch comments for each Pull Request and limit the number of comments returned.
* Update `PromptEvent` initialization in `scripts/generate_summary.py` to include comments in the `pull_requests` dictionary.
* Modify `prompt_event_macro` in `scripts/summary_template.html` to display text from comments in Pull Request.
* Limit the number of comments displayed in `scripts/summary_template.html` to stay within Github limits.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/156?shareId=07aab594-000e-48a6-9748-568e4605a305).