### PR TITLE
Get and show the first comment for each Pull Request contained in a PromptEvent

### DIFF
--- a/scripts/summary_template.html
+++ b/scripts/summary_template.html
@@ -40,6 +40,9 @@
           <a href="{{ pr.url }}" class="text-blue-500">Merged</a> {% else %} -
           <a href="{{ pr.url }}" class="text-blue-500">Unmerged</a>
           {% endif %}
+          {% if pr.first_comment %}
+          <div class="text-gray-600 mt-2">{{ pr.first_comment | safe }}</div>
+          {% endif %}
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
Related to #157

Add functionality to get and show the first comment for each Pull Request contained in a PromptEvent.

* Add `first_comment` attribute to `PromptEvent` class in `scripts/generate_summary.py` to store the first comment of each pull request.
* Modify `query_issues_and_prs` function in `scripts/generate_summary.py` to fetch the first comment for each pull request and store it in the `first_comment` attribute of `PromptEvent`.
* Update `render_template` function in `scripts/generate_summary.py` to include logic to display the first comment for each pull request in the template.
* Add placeholders in `scripts/summary_template.html` to display the first comment for each pull request.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory2/pull/158?shareId=9de4924c-b09c-4104-bdfb-bce4792c3715).